### PR TITLE
add wDebug to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/
+w[Dd]ebug/
 x64/
 build/
 bld/


### PR DESCRIPTION
This solution file can create otvdm/wDebug. We should ignore that for git.