### PR TITLE
make lsl work

### DIFF
--- a/vm86/mame/emu/cpu/i386/i386op32.c
+++ b/vm86/mame/emu/cpu/i386/i386op32.c
@@ -3441,7 +3441,7 @@ static void I386OP(lsl_r32_rm32)()  // Opcode 0x0f 0x03
 		else
 		{
 			UINT8 type;
-			if(!i386_load_protected_mode_segment(&seg,NULL))
+			if(!wine_load_protected_mode_segment(&seg,NULL))
 			{
 				SetZF(0);
 				return;

--- a/vm86/mame/emu/cpu/i386/i386priv.h
+++ b/vm86/mame/emu/cpu/i386/i386priv.h
@@ -560,6 +560,7 @@ extern MODRM_TABLE i386_MODRM_table[256];
 
 //
 UINT get_segment_descriptor_wine(int sreg);
+UINT32 wine_load_protected_mode_segment(I386_SREG *seg, UINT64 *desc);
 //
 INLINE UINT32 i386_translate(int segment, UINT32 ip, int rwn)
 {

--- a/vm86/msdos.cpp
+++ b/vm86/msdos.cpp
@@ -1854,7 +1854,7 @@ UINT32 wine_load_protected_mode_segment(I386_SREG *seg, UINT64 *desc)
 	if(!(seg->selector & 0x4))
 		return 0;
 
-	wine_ldt_get_entry(seg->selector & ~0x7, &entry);
+	wine_ldt_get_entry(seg->selector, &entry);
     v1 = ((const UINT32 *)&entry)[0];
 	v2 = ((const UINT32 *)&entry)[1];
 	if(!v1 && !v2)


### PR DESCRIPTION
Photoshop 2.5 uses the lsl instruction along with lots of dpmi in it's jpeg decoder which contains an ugly mix of 16 and 32 bit code.