### PR TITLE
real windows creates a selector 0x40 to point to the bios data area a…

### DIFF
--- a/krnl386/dosexe.h
+++ b/krnl386/dosexe.h
@@ -372,7 +372,7 @@ extern void DOSVM_ASPIHandler(CONTEXT*) DECLSPEC_HIDDEN;
 
 /* dosmem.c */
 extern BIOSDATA *DOSVM_BiosData( void ) DECLSPEC_HIDDEN;
-extern void DOSVM_start_bios_timer(void) DECLSPEC_HIDDEN;
+__declspec(dllexport) extern void DOSVM_start_bios_timer(void) DECLSPEC_HIDDEN;
 
 /* fpu.c */
 extern void WINAPI DOSVM_Int34Handler(CONTEXT*) DECLSPEC_HIDDEN;

--- a/krnl386/dosmem.c
+++ b/krnl386/dosmem.c
@@ -269,7 +269,7 @@ static DWORD CALLBACK timer_thread( void *arg )
  *
  * Start the BIOS ticks timer when the app accesses selector 0x40.
  */
-void DOSVM_start_bios_timer(void)
+__declspec(dllexport) void DOSVM_start_bios_timer(void)
 {
     static LONG running;
 

--- a/krnl386/interrupts.c
+++ b/krnl386/interrupts.c
@@ -869,13 +869,12 @@ static void WINAPI DOSVM_Int1aHandler( CONTEXT *context )
     {
     case 0x00: /* GET SYSTEM TIME */
         {
-            SYSTEMTIME systime;
-            GetLocalTime( &systime );
-            DWORD ticks = (float)(systime.wHour * 3600 + systime.wMinute * 60 + systime.wSecond) * 18.2f;
-            SET_CX( context, HIWORD(ticks) );
-            SET_DX( context, LOWORD(ticks) );
+            DOSVM_start_bios_timer();
+            BIOSDATA *data = DOSVM_BiosData();
+            SET_CX( context, HIWORD(data->Ticks) );
+            SET_DX( context, LOWORD(data->Ticks) );
             SET_AL( context, 0 ); /* FIXME: midnight flag is unsupported */
-            TRACE( "GET SYSTEM TIME - ticks=%d\n", ticks );
+            TRACE( "GET SYSTEM TIME - ticks=%d\n", data->Ticks );
         }
         break;
 


### PR DESCRIPTION
…t real mode address 0x40:0 this is a gdt selector so provide a valid selector instead, start the tick counter and skip the instruction

This seems to be done by many protected mode programs (foxpro 2.6 for example) to read the bios tick counter without doing an int 1a.