### PR TITLE
some programs expect there to be leftovers in a uninited block

### DIFF
--- a/krnl386/global.c
+++ b/krnl386/global.c
@@ -249,6 +249,7 @@ HGLOBAL16 GLOBAL_Alloc( UINT16 flags, DWORD size, HGLOBAL16 hOwner, unsigned cha
     }
 
     if (flags & GMEM_ZEROINIT) memset( ptr, 0, size );
+    else ((char *)ptr)[size - 1] = 0xff; // some programs depend on the block not being cleared
     return handle;
 }
 


### PR DESCRIPTION
Pagemaker will overrun it's buffer when parsing a file it loads.  It appears to be a programming error that doesn't occur in windows 1.0 because memory is constantly reused and there's no memory protection anyway.  I wouldn't expect that programs would have a problem with there being leftover data in memory when they don't use GMEM_ZEROINIT but it's possible there might be.  An alternative to this might be a framework to patch at runtime programs with bugs that rely on undefined behavior.