### PR TITLE
more global memory block overruns

### DIFF
--- a/krnl386/global.c
+++ b/krnl386/global.c
@@ -231,8 +231,8 @@ HGLOBAL16 GLOBAL_Alloc( UINT16 flags, DWORD size, HGLOBAL16 hOwner, unsigned cha
 
     /* Fixup the size */
 
-    if (size >= GLOBAL_MAX_ALLOC_SIZE - 0x1f) return 0;
-    size = (size + 0x1f) & ~0x1f;
+    if (size >= GLOBAL_MAX_ALLOC_SIZE - 0xff) return 0;
+    size = (size + 0xff) & ~0xff;
 
     /* Allocate the linear memory */
     ptr = HeapAlloc( get_win16_heap(), 0, size );
@@ -339,9 +339,9 @@ HGLOBAL16 WINAPI GlobalReAlloc16(
 
       /* Fixup the size */
 
-    if (size > GLOBAL_MAX_ALLOC_SIZE - 0x20) return 0;
-    if (size == 0) size = 0x20;
-    else size = (size + 0x1f) & ~0x1f;
+    if (size > GLOBAL_MAX_ALLOC_SIZE - 0x100) return 0;
+    if (size == 0) size = 0x100;
+    else size = (size + 0xff) & ~0xff;
 
       /* Change the flags */
 


### PR DESCRIPTION
I've found more buffer overruns in real mode programs.  Making the min globalalloc size to be 256 bytes rather than 32 fixes them but again it's possible that there are programs that won't like it.