### PR TITLE
prevent sign extension of dialog id in get/setdlgitemtext

### DIFF
--- a/user/dialog.c
+++ b/user/dialog.c
@@ -1109,7 +1109,7 @@ HWND16 WINAPI GetDlgItem16( HWND16 hwndDlg, INT16 id )
 void WINAPI SetDlgItemText16( HWND16 hwnd, INT16 id, SEGPTR lpString )
 {
 	const char *txt = MapSL(lpString);
-	SetDlgItemTextA(HWND_32(hwnd), id, txt);
+	SetDlgItemTextA(HWND_32(hwnd), (UINT16)id, txt);
     SendDlgItemMessage16( hwnd, id, WM_SETTEXT, 0, lpString );
 }
 
@@ -1119,7 +1119,7 @@ void WINAPI SetDlgItemText16( HWND16 hwnd, INT16 id, SEGPTR lpString )
  */
 INT16 WINAPI GetDlgItemText16( HWND16 hwnd, INT16 id, SEGPTR str, UINT16 len )
 {
-	return GetDlgItemTextA(HWND_32(hwnd), id, MapSL(str), len);
+	return GetDlgItemTextA(HWND_32(hwnd), (UINT16)id, MapSL(str), len);
     return SendDlgItemMessage16( hwnd, id, WM_GETTEXT, len, str );
 }
 


### PR DESCRIPTION
fixes code view dialog in VB1-3