### PR TITLE
add sizeof(STACK16FRAME)-4 to the initial stack size so the bx regist…

### DIFF
--- a/krnl386/ne_module.c
+++ b/krnl386/ne_module.c
@@ -1459,8 +1459,8 @@ DWORD NE_StartTask(void)
         if (!(sp = OFFSETOF(pModule->ne_sssp)))
             sp = pSegTable[SELECTOROF(pModule->ne_sssp)-1].minsize + pModule->ne_stack;
         sp &= ~1;
-        sp -= sizeof(STACK16FRAME);
-		setWOW32Reserved((void *)MAKESEGPTR(GlobalHandleToSel16(hInstance), sp));
+        sp += 4;
+        setWOW32Reserved((void *)MAKESEGPTR(GlobalHandleToSel16(hInstance), sp));
 
         /* Registers at initialization must be:
          * ax   zero

--- a/krnl386/ne_segment.c
+++ b/krnl386/ne_segment.c
@@ -1022,7 +1022,7 @@ BOOL NE_CreateSegment( NE_MODULE *pModule, int segnum )
         return TRUE;    /* all but DGROUP only allocated once */
 
     minsize = pSeg->minsize ? pSeg->minsize : 0x10000;
-    if ( segnum == SELECTOROF(pModule->ne_sssp) ) minsize += pModule->ne_stack;
+    if ( segnum == SELECTOROF(pModule->ne_sssp) ) minsize += pModule->ne_stack + sizeof(STACK16FRAME) - 4;
     if ( segnum == pModule->ne_autodata ) minsize += pModule->ne_heap;
 
     selflags = (pSeg->flags & NE_SEGFLAGS_DATA) ? WINE_LDT_FLAGS_DATA : WINE_LDT_FLAGS_CODE;


### PR DESCRIPTION
…er at task start contains the available stack size rather than the allocated size

This fixes https://github.com/otya128/winevdm/issues/45 .