### PR TITLE
only lock discardable memory

### DIFF
--- a/krnl386/global.c
+++ b/krnl386/global.c
@@ -505,7 +505,7 @@ SEGPTR WINAPI K32WOWGlobalLock16( HGLOBAL16 handle )
 	}
 	else if (!GET_ARENA_PTR(handle)->base)
             sel = 0;
-        else
+        else if (GET_ARENA_PTR(handle)->flags & GA_DISCARDABLE)
             GET_ARENA_PTR(handle)->lockCount++;
     }
 
@@ -717,7 +717,8 @@ LPVOID WINAPI GlobalLock16(
     if (!handle) return 0;
     if (!VALID_HANDLE(handle))
 	return 0;
-    GET_ARENA_PTR(handle)->lockCount++;
+    if (GET_ARENA_PTR(handle)->flags & GA_DISCARDABLE)
+        GET_ARENA_PTR(handle)->lockCount++;
     return GET_ARENA_PTR(handle)->base;
 }
 
@@ -863,7 +864,8 @@ HGLOBAL16 WINAPI LockSegment16( HGLOBAL16 handle )
 	WARN("Invalid handle 0x%04x passed to LockSegment16!\n",handle);
 	return 0;
     }
-    GET_ARENA_PTR(handle)->lockCount++;
+    if (GET_ARENA_PTR(handle)->flags & GA_DISCARDABLE)
+        GET_ARENA_PTR(handle)->lockCount++;
     return handle;
 }
 
@@ -879,7 +881,7 @@ void WINAPI UnlockSegment16( HGLOBAL16 handle )
 	WARN("Invalid handle 0x%04x passed to UnlockSegment16!\n",handle);
 	return;
     }
-    GET_ARENA_PTR(handle)->lockCount--;
+    if(GET_ARENA_PTR(handle)->lockCount) GET_ARENA_PTR(handle)->lockCount--;
     /* FIXME: this ought to return the lock count in CX (go figure...) */
 }
 
@@ -1070,7 +1072,8 @@ WORD WINAPI GlobalFix16( HGLOBAL16 handle )
 	WARN("Invalid handle 0x%04x passed to GlobalFix16!\n",handle);
 	return 0;
     }
-    GET_ARENA_PTR(handle)->lockCount++;
+    if (GET_ARENA_PTR(handle)->flags & GA_DISCARDABLE)
+        GET_ARENA_PTR(handle)->lockCount++;
 
     return GlobalHandleToSel16(handle);
 }
@@ -1087,7 +1090,8 @@ void WINAPI GlobalUnfix16( HGLOBAL16 handle )
 	WARN("Invalid handle 0x%04x passed to GlobalUnfix16!\n",handle);
 	return;
     }
-    GET_ARENA_PTR(handle)->lockCount--;
+    if (GET_ARENA_PTR(handle)->lockCount)
+        GET_ARENA_PTR(handle)->lockCount--;
 }
 
 


### PR DESCRIPTION
with GlobalLock.
verified on windows 3.1 fixes https://web.archive.org/web/20020206231256fw_/http://193.129.255.5/mopyfish/binaries/setup.exe

I also verified that LocalLock is correct that it only locks moveable memory.