### PR TITLE
make bx non-zero when calling a window proc

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -443,6 +443,7 @@ DWORD call_native_wndproc_context(CONTEXT *context)
     context.SegGs = wine_get_gs();
     context.Eax = !hwnd ? 0 : GetWindowWord16(hwnd, GWLP_HINSTANCE) | 1; /* Handle To Sel */
     if (!context.Eax) context.Eax = context.SegDs;
+    context.Ebx = 6;
     context.SegCs = SELECTOROF(func);
     context.Eip   = OFFSETOF(func);
     context.Ebp   = OFFSETOF(getWOW32Reserved()) + FIELD_OFFSET(STACK16FRAME, bp);


### PR DESCRIPTION
At least one program depends on bx not being 0 when entering it's wndproc.  Win31 leaves bx set to the offset of a struct pointer which is fairly random but Winxp/ntvdm always sets it to 6 so I when with that.