### PR TITLE
ignore invalid values in high byte of colorref

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -72,10 +72,23 @@ struct dib_driver
 };
 static struct list dib_drivers = LIST_INIT(dib_drivers);
 
+// on windows 3.1 in 8bit color mode:
+// RGB() is matched to the 20 system colors
+// PALETTEINDEX() is a direct index to the hdc palette, 0 if out of range
+// PALETTERGB() is matched to the hdc palette
+// DIBINDEX() doesn't exist
+// color is treated as RGB() unless high byte is exactly 1 or 2
+//
+// on windows 10 in 24bit color mode:
+// RGB() is the direct color
+// PALETTEINDEX() is a direct index to the hdc palette, 0 if out of range
+// PALETTERGB() is the direct color
+// DIBINDEX() is 0 for non-dib hdcs
+// color is treated as PALETTEINDEX() if low bit of high byte is set
 static COLORREF check_colorref(COLORREF color)
 {
-    int type = color >> 16;
-    if ((type != 0x10ff) && ((type & 0xf00) != 0x100) && ((type & 0xf00) != 0x200))
+    int type = (color >> 24);
+    if ((type != 1) && (type != 2))
         color &= 0xffffff;
     return color;
 }

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -983,7 +983,10 @@ INT16 WINAPI SaveDC16( HDC16 hdc )
  */
 COLORREF WINAPI SetPixel16( HDC16 hdc, INT16 x, INT16 y, COLORREF color )
 {
-    return SetPixel( HDC_32(hdc), x, y, color );
+    int type = color >> 16;
+    if ((type != 0x10ff) || (type != 0x100) || ((type & 0xf00) != 0x200))
+        color &= 0xffffff;
+    return SetPixel( HDC_32(hdc), x, y, color);
 }
 
 

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -74,21 +74,23 @@ static struct list dib_drivers = LIST_INIT(dib_drivers);
 
 // on windows 3.1 in 8bit color mode:
 // RGB() is matched to the 20 system colors
-// PALETTEINDEX() is a direct index to the hdc palette, 0 if out of range
-// PALETTERGB() is matched to the hdc palette
-// DIBINDEX() doesn't exist
-// color is treated as RGB() unless high byte is exactly 1 or 2
+// PALETTEINDEX() is a direct index to the dc palette, 0 if out of range
+// PALETTERGB() is matched to the dc palette
+// DIBINDEX() only applies to dib.drv dcs
+// color is treated as RGB() unless high byte is exactly 1, 2 or high word 0x10ff for DIBINDEX()
 //
 // on windows 10 in 24bit color mode:
 // RGB() is the direct color
-// PALETTEINDEX() is a direct index to the hdc palette, 0 if out of range
+// PALETTEINDEX() is a direct index to the dc palette, 0 if out of range
 // PALETTERGB() is the direct color
-// DIBINDEX() is 0 for non-dib hdcs
-// color is treated as PALETTEINDEX() if low bit of high byte is set
+// DIBINDEX() is 0 for non-dib dcs
+// color is treated as PALETTEINDEX() if bit 16 is set else DIBINDEX() if bit 24 is set and byte 3 is 0xff
+//
+// ntvdm in 8bit color mode behaves like win3.1 with DIBINDEX()
 static COLORREF check_colorref(COLORREF color)
 {
-    int type = (color >> 24);
-    if ((type != 1) && (type != 2))
+    int type = color >> 16;
+    if ((type != 0x10ff) && ((type & 0xff00) != 0x100) && ((type & 0xff00) != 0x200))
         color &= 0xffffff;
     return color;
 }

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -71,6 +71,15 @@ struct dib_driver
     DWORD       padding;
 };
 static struct list dib_drivers = LIST_INIT(dib_drivers);
+
+static COLORREF check_colorref(COLORREF color)
+{
+    int type = color >> 16;
+    if ((type != 0x10ff) && ((type & 0xf00) != 0x100) && ((type & 0xf00) != 0x200))
+        color &= 0xffffff;
+    return color;
+}
+
 /*
  * ############################################################################
  */
@@ -677,7 +686,7 @@ static struct window_surface *create_surface( const BITMAPINFO *info )
  */
 COLORREF WINAPI SetBkColor16( HDC16 hdc, COLORREF color )
 {
-    return SetBkColor( HDC_32(hdc), color );
+    return SetBkColor( HDC_32(hdc), check_colorref(color) );
 }
 
 
@@ -752,7 +761,7 @@ INT16 WINAPI SetTextCharacterExtra16( HDC16 hdc, INT16 extra )
  */
 COLORREF WINAPI SetTextColor16( HDC16 hdc, COLORREF color )
 {
-    return SetTextColor( HDC_32(hdc), color );
+    return SetTextColor( HDC_32(hdc), check_colorref(color) );
 }
 
 
@@ -924,7 +933,7 @@ BOOL16 WINAPI Ellipse16( HDC16 hdc, INT16 left, INT16 top,
  */
 BOOL16 WINAPI FloodFill16( HDC16 hdc, INT16 x, INT16 y, COLORREF color )
 {
-    return ExtFloodFill( HDC_32(hdc), x, y, color, FLOODFILLBORDER );
+    return ExtFloodFill( HDC_32(hdc), x, y, check_colorref(color), FLOODFILLBORDER );
 }
 
 
@@ -983,10 +992,7 @@ INT16 WINAPI SaveDC16( HDC16 hdc )
  */
 COLORREF WINAPI SetPixel16( HDC16 hdc, INT16 x, INT16 y, COLORREF color )
 {
-    int type = color >> 16;
-    if ((type != 0x10ff) && (type != 0x100) && ((type & 0xf00) != 0x200))
-        color &= 0xffffff;
-    return SetPixel( HDC_32(hdc), x, y, color);
+    return SetPixel( HDC_32(hdc), x, y, check_colorref(color) );
 }
 
 
@@ -1711,7 +1717,7 @@ HRGN16 WINAPI CreateRectRgnIndirect16( const RECT16* rect )
  */
 HBRUSH16 WINAPI CreateSolidBrush16( COLORREF color )
 {
-    return HBRUSH_16( CreateSolidBrush( color ) );
+    return HBRUSH_16( CreateSolidBrush( check_colorref(color) ) );
 }
 
 

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -984,7 +984,7 @@ INT16 WINAPI SaveDC16( HDC16 hdc )
 COLORREF WINAPI SetPixel16( HDC16 hdc, INT16 x, INT16 y, COLORREF color )
 {
     int type = color >> 16;
-    if ((type != 0x10ff) || (type != 0x100) || ((type & 0xf00) != 0x200))
+    if ((type != 0x10ff) && (type != 0x100) && ((type & 0xf00) != 0x200))
         color &= 0xffffff;
     return SetPixel( HDC_32(hdc), x, y, color);
 }


### PR DESCRIPTION
Windows 1.0-3.1 ignores bad values in the msb of a colorref dword but NT rejects it.