### PR TITLE
don't check used in the second loop so thunks can get reused

### DIFF
--- a/user/dialog.c
+++ b/user/dialog.c
@@ -645,12 +645,9 @@ DLGPROC allocate_proc_thunk(LPVOID param, LPVOID func)
     }
     for (int i = 0; i < MAX_THUNK; i++)
     {
-        if (!thunk_array[i].used && thunk_array[i].hDlg)
+        if (thunk_array[i].hDlg && !IsWindow(thunk_array[i].hDlg))
         {
-            if (!IsWindow(thunk_array[i].hDlg))
-            {
-                return (DLGPROC)init_thunk_data(param, i, func);
-            }
+            return (DLGPROC)init_thunk_data(param, i, func);
         }
     }
     ERR("could not allocate dialog thunk!\n");


### PR DESCRIPTION
Hopefully fixes https://github.com/otya128/winevdm/issues/122