### PR TITLE
if a dc was already released, don't fail deletedc

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -1775,6 +1775,8 @@ BOOL16 WINAPI DeleteDC16( HDC16 hdc )
         K32WOWHandle16DestroyHint(hdc32, WOW_TYPE_HDC /* GDIOBJ */);
         return TRUE;
     }
+    else if (!GetObjectType(hdc32))
+        return TRUE; // Assume object was already released
     return FALSE;
 }
 


### PR DESCRIPTION
Exile 3 calls ReleaseDC and DeleteDC on the same DC and expects both to succeed otherwise it exits.  It works properly in NTVDM.  I'm not sure what is supposed to happen but I think that just checking that the handle isn't allocated should be harmless.  Fixes https://github.com/otya128/winevdm/issues/133 .