### PR TITLE
use the exe module path for the help file which is where it's probabl…

### DIFF
--- a/user/winhelp.c
+++ b/user/winhelp.c
@@ -205,6 +205,7 @@ BOOL WINAPI wine_WinHelp32A(HWND hWnd, LPCSTR lpHelpFile, UINT wCommand, ULONG_P
     HWND                hDest;
     int                 size, dsize, nlen, plen;
     char                path[MAX_PATH];
+    char*               pathend;
     WINEHELP*           lpwh;
     LRESULT             ret;
 
@@ -290,8 +291,15 @@ BOOL WINAPI wine_WinHelp32A(HWND hWnd, LPCSTR lpHelpFile, UINT wCommand, ULONG_P
     }
     if (lpHelpFile)
     {
-        GetCurrentDirectoryA(MAX_PATH, path);
-        plen = strlen(path) + 1;
+        GetModuleFileName16(NULL, path, MAX_PATH);
+        pathend = strrchr(path, '\\');
+        if (pathend)
+        {
+            *pathend = '\0';
+            plen = strlen(path) + 1;
+        }
+        else
+            plen = 0;
         nlen = strlen(lpHelpFile) + 1;
     }
     else

--- a/winhlp32/hlpfile.c
+++ b/winhlp32/hlpfile.c
@@ -2060,6 +2060,12 @@ static BOOL HLPFILE_SystemCommands(HLPFILE* hlpfile)
     if (hlpfile->version <= 16)
     {
         char *str = (char*)buf + 0x15;
+        if (*str == 0)
+        {
+            str = strrchr(hlpfile->lpszPath, '\\') + 1;
+            if (str == 1)
+                str = hlpfile->lpszPath;
+        }
 
         hlpfile->lpszTitle = HeapAlloc(GetProcessHeap(), 0, strlen(str) + 1);
         if (!hlpfile->lpszTitle) return FALSE;


### PR DESCRIPTION
…y found and use the help file name if the caption appears to be empty