### PR TITLE
make si non-zero when calling a window proc

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -450,6 +450,7 @@ DWORD call_native_wndproc_context(CONTEXT *context)
     context.Eax = !hwnd ? 0 : GetWindowWord16(hwnd, GWLP_HINSTANCE) | 1; /* Handle To Sel */
     if (!context.Eax) context.Eax = context.SegDs;
     context.Ebx = 6;
+    context.Esi = hwnd;
     context.SegCs = SELECTOROF(func);
     context.Eip   = OFFSETOF(func);
     context.Ebp   = OFFSETOF(getWOW32Reserved()) + FIELD_OFFSET(STACK16FRAME, bp);


### PR DESCRIPTION
Like bx, si is (usually) not 0 when calling to a window proc.  In win31 it's set to a pointer somewhere in ram but ntvdm sets it to the hwnd so go with that.

Fixes https://github.com/otya128/winevdm/issues/180