### PR TITLE
use unicode function with wchar when reading drive label

### DIFF
--- a/krnl386/int21.c
+++ b/krnl386/int21.c
@@ -3896,7 +3896,7 @@ static unsigned INT21_FindHelper(LPCWSTR fullPath, unsigned drive, unsigned coun
         if (count) return 0;
         path[0] = drive + 'A';
         entry->cAlternateFileName[0] = '\0';
-        if (!GetVolumeInformationA(path, entry->cAlternateFileName, 13, NULL, NULL, NULL, NULL, 0)) return 0;
+        if (!GetVolumeInformationW(path, entry->cAlternateFileName, 13, NULL, NULL, NULL, NULL, 0)) return 0;
         if (!entry->cAlternateFileName[0]) return 0;
         RtlSecondsSince1970ToTime( 0, (LARGE_INTEGER *)&entry->ftCreationTime );
         RtlSecondsSince1970ToTime( 0, (LARGE_INTEGER *)&entry->ftLastAccessTime );


### PR DESCRIPTION
fixes part of https://github.com/otya128/winevdm/issues/223