### PR TITLE
load fonts from redirected windows\system dir

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -4687,7 +4687,7 @@ BOOL WINAPI DllEntryPoint(DWORD fdwReason, HINSTANCE hinstDLL, WORD ds,
             }
             FindNextFileA(file, &fileinfo);
         }
-        CloseHandle(file);
+        FindClose(file);
         break;
     }
     case DLL_PROCESS_DETACH:

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -4652,3 +4652,46 @@ WORD WINAPI GetFontAssocStatus16(HDC16 hdc)
     }
     return ((ULONG(WINAPI*)(HDC))GetFontAssocStatus)(HDC_32(hdc));
 }
+
+LPCSTR RedirectSystemDir(LPCSTR path, LPSTR to, size_t max_len);
+
+BOOL WINAPI DllEntryPoint(DWORD fdwReason, HINSTANCE hinstDLL, WORD ds,
+                          WORD wHeapSize, DWORD dwReserved1, WORD wReserved2)
+{
+    switch (fdwReason)
+    {
+    case DLL_PROCESS_ATTACH:
+    {
+        static BOOL init = FALSE;
+        if (init == TRUE)
+            break;
+        init = TRUE;
+        WIN32_FIND_DATAA fileinfo = {0};
+        char syspath[MAX_PATH];
+        char fonfile[MAX_PATH];
+        RedirectSystemDir("C:\\Windows\\System\\", syspath, MAX_PATH);
+        strcpy(fonfile, syspath);
+        strcat(fonfile, "*.*");
+        HANDLE file = FindFirstFileA(fonfile, &fileinfo);
+        if (file == INVALID_HANDLE_VALUE)
+            break;
+
+        while (GetLastError() == ERROR_SUCCESS)
+        {
+            LPCSTR *ext = fileinfo.cFileName + strlen(fileinfo.cFileName) - 4;
+            if (!stricmp(ext, ".ttf") || !stricmp(ext, ".fon"))
+            {
+                strcpy(fonfile, syspath);
+                strcat(fonfile, fileinfo.cFileName);
+                AddFontResource16(fonfile);
+            }
+            FindNextFileA(file, &fileinfo);
+        }
+        CloseHandle(file);
+        break;
+    }
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}

--- a/gdi/gdi.exe16.spec
+++ b/gdi/gdi.exe16.spec
@@ -415,3 +415,5 @@
 824 stub ICMCheckColorsInGamut
 1000 pascal -ret16 SetLayout(word long) SetLayout16
 1001 stub GetLayout
+
+5000 pascal DllEntryPoint(long word word word long word) DllEntryPoint


### PR DESCRIPTION
this fixes the wrong fonts in "Keroppi Day Hopper" and presumably anything else that has an installer that drops the fonts in the system dir