### PR TITLE
fix various problems with word 1.0

### DIFF
--- a/user/dialog.c
+++ b/user/dialog.c
@@ -111,7 +111,12 @@ static LPCSTR DIALOG_GetControl16( LPCSTR p, DLG_CONTROL_INFO *info )
     {
         switch((BYTE)*p)
         {
-            case 0x80: strcpy( buffer, "BUTTON" ); break;
+            case 0x80: strcpy( buffer, "BUTTON" );
+                // this is undocumented but makes BS_USERBUTTON work
+                // BS_ICON and BS_BITMAP work without it
+                if (((info->style & 0xf) == BS_USERBUTTON) && !(info->style & 0xc0))
+                    info->style |= 0x10;
+                break;
             case 0x81: strcpy( buffer, "EDIT" ); break;
             case 0x82: strcpy( buffer, "STATIC" ); break;
             case 0x83: strcpy( buffer, "LISTBOX" ); break;

--- a/user/message.c
+++ b/user/message.c
@@ -2805,6 +2805,7 @@ LRESULT WINAPI DefDlgProc16( HWND16 hwnd, UINT16 msg, WPARAM16 wParam, LPARAM lP
 }
 
 
+BOOL16 WINAPI IsOldWindowsTask(HINSTANCE16 hInst);
 /***********************************************************************
  *		PeekMessage  (USER.109)
  */
@@ -2825,6 +2826,8 @@ BOOL16 WINAPI PeekMessage16( MSG16 *msg, HWND16 hwnd,
     {
         RestoreThunkLock(count);
     }
+    if (IsOldWindowsTask(GetCurrentTask()) && !msg->hwnd)
+        msg->hwnd = HWND_16(GetDesktopWindow());
     return ret;
 }
 

--- a/user/window.c
+++ b/user/window.c
@@ -324,6 +324,11 @@ UINT16 WINAPI SetTimer16( HWND16 hwnd, UINT16 id, UINT16 timeout, TIMERPROC16 pr
 UINT16 WINAPI SetSystemTimer16( HWND16 hwnd, UINT16 id, UINT16 timeout, TIMERPROC16 proc )
 {
     TIMERPROC proc32 = proc == NULL ? NULL : allocate_timer_thunk(proc, TimerProc_Thunk, TRUE);
+    if (!SetSystemTimer)
+    {
+        ERR("SetSystemTimer NULL\n");
+        return 0;
+    }
     return SetSystemTimer( WIN_Handle32(hwnd), id, timeout, proc32 );
 }
 
@@ -1801,6 +1806,11 @@ void WINAPI SwitchToThisWindow16( HWND16 hwnd, BOOL16 restore )
  */
 BOOL16 WINAPI KillSystemTimer16( HWND16 hwnd, UINT16 id )
 {
+    if (!KillSystemTimer)
+    {
+        ERR("KillSystemTimer NULL\n");
+        return 0;
+    }
     return KillSystemTimer( WIN_Handle32(hwnd), id );
 }
 


### PR DESCRIPTION
Word 1.0 blows up if there's a message with a null hwnd so work around that, it also calls set/killsystemtimer which don't exist on windows 10 (it seems to work fine even if they do nothing) and add an undocumented window style that makes bs_userbutton function.