### PR TITLE
force wm_dde_execute to use postmessage

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -2542,6 +2542,10 @@ LRESULT WINAPI SendMessage16( HWND16 hwnd16, UINT16 msg, WPARAM16 wparam, LPARAM
     LRESULT result;
     HWND hwnd = WIN_Handle32( hwnd16 );
 
+    // SendMessageTimeout always fails with this message
+    if (msg == WM_DDE_EXECUTE)
+       return PostMessage16( hwnd16, msg, wparam, lparam );
+
     if (hwnd != HWND_BROADCAST &&
         GetWindowThreadProcessId( hwnd, NULL ) == GetCurrentThreadId())
     {


### PR DESCRIPTION
msdn says to use postmessage https://docs.microsoft.com/en-us/windows/desktop/dataxchg/wm-dde-execute

fixes https://github.com/otya128/winevdm/issues/247