### PR TITLE
after winexec wait for task input idle (getmessage or sendmessage)

### DIFF
--- a/krnl386/kernel16_private.h
+++ b/krnl386/kernel16_private.h
@@ -736,10 +736,11 @@ struct kernel_thread_data
     WORD                htask16;        /* Win16 task handle */
     DWORD               sys_count[4];   /* syslevel mutex entry counters */
     struct tagSYSLEVEL *sys_mutex[4];   /* syslevel mutex pointers */
+    HANDLE              idle_event;     /* input idle event */
     int                 curdir_len;     /* current dir buffer length */
     char               *true_curdir;    /* true current dir */
     char               *curdir_buf;     /* current dir buffer */
-    void               *pad[33];        /* change this if you add fields! */
+    void               *pad[29];        /* change this if you add fields! */
 };
 
 __declspec(dllexport) struct kernel_thread_data *tls_get_kernel_thread_data();

--- a/krnl386/task.c
+++ b/krnl386/task.c
@@ -573,6 +573,7 @@ static DWORD CALLBACK task_start( LPVOID p )
     DWORD ret;
 
     kernel_get_thread_data()->htask16 = pTask->hSelf;
+    kernel_get_thread_data()->idle_event = CreateEventA(NULL, TRUE, FALSE, NULL);
     NtCurrentTeb()->Tib.SubSystemTib = data->tib;
 
     set_thread_internal_windows_ver(0x30A);
@@ -708,6 +709,7 @@ void TASK_ExitTask(void)
 
     /* Remove the task from the list to be sure we never switch back to it */
     TASK_UnlinkTask( pTask->hSelf );
+    CloseHandle(kernel_get_thread_data()->idle_event);
 
     if (!nTaskCount || (nTaskCount == 1 && hFirstTask == initial_task))
     {

--- a/user/message.c
+++ b/user/message.c
@@ -32,6 +32,7 @@
 #include "user_private.h"
 #include "wine/debug.h"
 #include "message_table.h"
+#include "../krnl386/kernel16_private.h"
 /*
 unknwon combobox message
 When EDIT received WM_KILLFOCUS, EDIT sent this message to COMBOBOX.
@@ -2541,6 +2542,7 @@ LRESULT WINAPI SendMessage16( HWND16 hwnd16, UINT16 msg, WPARAM16 wparam, LPARAM
 {
     LRESULT result;
     HWND hwnd = WIN_Handle32( hwnd16 );
+    SetEvent(kernel_get_thread_data()->idle_event);
 
     // SendMessageTimeout always fails with this message
     if (msg == WM_DDE_EXECUTE)
@@ -2845,6 +2847,7 @@ BOOL16 WINAPI GetMessage32_16( MSG32_16 *msg16, HWND16 hwnd16, UINT16 first,
     MSG msg;
     LRESULT unused;
     HWND hwnd = WIN_Handle32( hwnd16 );
+    SetEvent(kernel_get_thread_data()->idle_event);
 
     if(USER16_AlertableWait)
         MsgWaitForMultipleObjectsEx( 0, NULL, INFINITE, 0, MWMO_ALERTABLE );


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/147 and helps https://github.com/otya128/winevdm/issues/247 get further.

I wouldn't be surprised to see regressions with this but basic testing with the few programs that use winexec, I didn't see any glaring issues.