### PR TITLE
mask off the upper 8 bits for internalref relocation segments

### DIFF
--- a/krnl386/ne_segment.c
+++ b/krnl386/ne_segment.c
@@ -231,7 +231,7 @@ static inline BOOL apply_relocations( NE_MODULE *pModule, const struct relocatio
             }
             else
             {
-                address = (FARPROC16)MAKESEGPTR( SEL(pSegTable[rep->target1-1].hSeg), rep->target2 );
+                address = (FARPROC16)MAKESEGPTR( SEL(pSegTable[(rep->target1 & 0xff)-1].hSeg), rep->target2 );
             }
 
             TRACE("%d: %04x:%04x %s\n",


### PR DESCRIPTION
fixes toolbook 3
The docs say that byte should be 0 so I'm not sure why it isn't here.