### PR TITLE
include path in reduced environment and capitalize vars

### DIFF
--- a/krnl386/task.c
+++ b/krnl386/task.c
@@ -1928,8 +1928,14 @@ SEGPTR WINAPI GetDOSEnvironment16(void)
             {
                 if (env_var_limit(p))
                 {
-                    for (int i = 0; i < strlen(p) + 1; i++)
+                    int i;
+                    for (i = 0; i < strlen(p) + 1; i++)
+                    {
+                        if (p[i] == '=')
+                            break;
                         env16p[i] = toupper(p[i]);
+                    }
+                    memcpy(env16p + i, p + i, strlen(p) + 1 - i);
                     env16p += strlen(p) + 1;
                 }
                 p += strlen(p) + 1;

--- a/krnl386/task.c
+++ b/krnl386/task.c
@@ -1861,7 +1861,7 @@ DWORD WINAPI GetAppCompatFlags16( HTASK16 hTask )
 
 const char *env_var_limitation[] =
 {
-    "", "COMSPEC", "TEMP", "TMP",
+    "", "COMSPEC", "TEMP", "TMP", "PATH"
 };
 BOOL env_var_limit(const char *v)
 {
@@ -1928,7 +1928,8 @@ SEGPTR WINAPI GetDOSEnvironment16(void)
             {
                 if (env_var_limit(p))
                 {
-                    memcpy(env16p, p, strlen(p) + 1);
+                    for (int i = 0; i < strlen(p) + 1; i++)
+                        env16p[i] = toupper(p[i]);
                     env16p += strlen(p) + 1;
                 }
                 p += strlen(p) + 1;

--- a/krnl386/task.c
+++ b/krnl386/task.c
@@ -1916,7 +1916,7 @@ SEGPTR WINAPI GetDOSEnvironment16(void)
             p += strlen(p) + 1;
         }
         size++;  /* skip last null */
-        size += sizeof(WORD) + sizeof(ENV_program_name);
+        size += sizeof(WORD) + sizeof(ENV_program_name) + 1;
         handle = GlobalAlloc16( GMEM_FIXED, size );
         if (handle)
         {
@@ -1943,6 +1943,7 @@ SEGPTR WINAPI GetDOSEnvironment16(void)
             memcpy( env16p, &one, sizeof(one));
             env16p += sizeof(one);
             memcpy( env16p, ENV_program_name, sizeof(ENV_program_name));
+            *(env16p + sizeof(ENV_program_name) + 1) = 0;
             GlobalUnlock16( handle );
         }
         FreeEnvironmentStringsA( env );


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/312
I verified that ntvdm does the capitalization.  It also converts the path entries to short names which may (or may not) be needed in the future.