### PR TITLE
try again with unpackddelparam

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -34,7 +34,9 @@
 #include "message_table.h"
 #include "../krnl386/kernel16_private.h"
 #include "commctrl.h"
- /*
+#include "wine/exception.h"
+
+/*
 unknwon combobox message
 When EDIT received WM_KILLFOCUS, EDIT sent this message to COMBOBOX.
 */
@@ -2135,7 +2137,7 @@ LRESULT WINPROC_CallProc32ATo16( winproc_callback16_t callback, HWND hwnd, UINT 
             int flag = 0;
             char buf[256];
 
-            __try
+            __TRY
             {
                 // if bit 4 is not set it's either a pointer or atom
                 if (!(lParam & 4))
@@ -2146,11 +2148,12 @@ LRESULT WINPROC_CallProc32ATo16( winproc_callback16_t callback, HWND hwnd, UINT 
                     hi = HIWORD(lParam);
                 }
             }
-            __except(EXCEPTION_EXECUTE_HANDLER)
+            __EXCEPT_ALL
             {
                 lo = LOWORD(lParam);
                 hi = HIWORD(lParam);
             }
+	    __ENDTRY
 
             if (hi >= 0xc000 && GlobalGetAtomNameA((ATOM)hi, buf, sizeof(buf)) > 0) flag |= 1;
             if (HIWORD(hi) && GlobalSize((HANDLE)hi) != 0) flag |= 2;

--- a/user/message.c
+++ b/user/message.c
@@ -2135,8 +2135,18 @@ LRESULT WINPROC_CallProc32ATo16( winproc_callback16_t callback, HWND hwnd, UINT 
             int flag = 0;
             char buf[256];
 
-            // UnpackDDElParam fails with HEAP_FAILURE_INVALID_ARGUMENT if lParam doesn't have bit 2 set
-            if (!(lParam & 4) || !UnpackDDElParam( msg, lParam, &lo, &hi ))
+            __try
+            {
+                // if bit 4 is not set it's either a pointer or atom
+                if (!(lParam & 4))
+                    lo = *(UINT *)lParam;
+                if (!UnpackDDElParam( msg, lParam, &lo, &hi ))
+                {
+                    lo = LOWORD(lParam);
+                    hi = HIWORD(lParam);
+                }
+            }
+            __except(EXCEPTION_EXECUTE_HANDLER)
             {
                 lo = LOWORD(lParam);
                 hi = HIWORD(lParam);


### PR DESCRIPTION
There doesn't seem to be any direct way to tell if lparam is a pointer, ghandle or atom.  If it's an atom and bit 4 is not set unpackddelparam will try to use it as a pointer and crash with an uncatchable fault if (void *)atom doesn't happen to be valid.  So I try to access the address first to force a catchable fault.