### PR TITLE
don't try to call int3 handler if toolhelp isn't loaded

### DIFF
--- a/krnl386/interrupts.c
+++ b/krnl386/interrupts.c
@@ -1113,6 +1113,8 @@ static void WINAPI DOSVM_Int01Handler(CONTEXT *context)
 static void WINAPI DOSVM_Int03Handler(CONTEXT *context)
 {
     HMODULE toolhelp = GetModuleHandleA("toolhelp.dll16");
+    if (!toolhelp)
+        return;
     SEGPTR stack = MAKESEGPTR(context->SegSs, context->Esp);
     FARPROC16 intcb = ((FARPROC16(WINAPI *)(SEGPTR *, SEGPTR, WORD, WORD, WORD))GetProcAddress(toolhelp, "get_intcb"))(&stack, MAKESEGPTR(context->SegCs, context->Eip), context->EFlags, 3, context->Eax);
     if (intcb)


### PR DESCRIPTION
Fixes regression with Sierra games Gabriel Knight and Kings quest 7 that probably use int 3 as debug/crack deterrence.