### PR TITLE
add some win30 compatibility hacks

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -1997,10 +1997,15 @@ BOOL16 WINAPI SetWindowPos16( HWND16 hwnd, HWND16 hwndInsertAfter,
     {
         hwnd32 = HWND_NOTOPMOST;
     }
-    if (flags & SWP_NOREDRAW)
+    if ((flags & SWP_NOREDRAW) && (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a))
     {
         RECT rect;
         GetWindowRect(hwnd32, &rect);
+        /* top-level window */
+        if (GetAncestor(hwnd32, GA_PARENT) == GetDesktopWindow())
+        {
+            flags &= ~SWP_NOREDRAW;
+        }
         if (rect.left == rect.right || rect.bottom == rect.top)
         {
             flags &= ~SWP_NOREDRAW;


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/360

The paint change might be too aggressive but hopefully will cause windows outside the parent rectangle to get paint messages along with the other children that will get paint messages anyway.