### PR TITLE
add 486 opcodes

### DIFF
--- a/vm86/msdos.cpp
+++ b/vm86/msdos.cpp
@@ -1007,7 +1007,7 @@ extern "C"
 		CPU_INIT_CALL(CPU_MODEL);
 		//enable x87
 		build_x87_opcode_table();
-		build_opcode_table(OP_I386 | OP_FPU);
+		build_opcode_table(OP_I386 | OP_FPU | OP_I486);
 		CPU_RESET_CALL(CPU_MODEL);
         UINT8 *base = 0;//mem;
 		m_idtr.base = (UINT32)(table - base);


### PR DESCRIPTION
fixes audio in https://github.com/otya128/winevdm/issues/376 which uses bswap in it's layer 3 decoder