### PR TITLE
fix video playback in dk space encyclopedia

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -178,7 +178,10 @@ static LRESULT call_window_proc_callback( HWND hwnd, UINT msg, WPARAM wp, LPARAM
                                           LRESULT *result, void *arg )
 {
     WNDPROC proc = arg;
+    DWORD count;
+    ReleaseThunkLock(&count);
     *result = CallWindowProcA( proc, hwnd, msg, wp, lp );
+    RestoreThunkLock(count);
     return *result;
 }
 

--- a/user/window.c
+++ b/user/window.c
@@ -2025,7 +2025,11 @@ BOOL16 WINAPI SetWindowPos16( HWND16 hwnd, HWND16 hwndInsertAfter,
  */
 HWND16 WINAPI SetParent16( HWND16 hwndChild, HWND16 hwndNewParent )
 {
-    return HWND_16( SetParent( WIN_Handle32(hwndChild), WIN_Handle32(hwndNewParent) ));
+    DWORD count;
+    ReleaseThunkLock(&count);
+    HWND16 hwnd16 = HWND_16( SetParent( WIN_Handle32(hwndChild), WIN_Handle32(hwndNewParent) ));
+    RestoreThunkLock(count);
+    return hwnd16;
 }
 
 


### PR DESCRIPTION
https://archive.org/details/Dorling_Kindersley_Eyewitness_Encyclopedia_Space_Universe_-_Win31-Mac_Eng

Since the avi player windows is in it's own thread but the program sets a 16bit wndproc this depends on non-task threads having a win16 stack so lazy attach (https://github.com/otya128/winevdm/blob/master/krnl386/kernel.c#L48) would break it.

I did a quick check but regressions caused by releasing the thunk lock before CallWindowProcA are possible.