### PR TITLE
handle case where section doesn't exist and entry is null but def_val…

### DIFF
--- a/krnl386/file.c
+++ b/krnl386/file.c
@@ -1458,7 +1458,10 @@ INT16 WINAPI GetPrivateProfileString16( LPCSTR section, LPCSTR entry,
             if (!ret)
             {
                 HeapFree( GetProcessHeap(), 0, data );
-                return construct_redirected_ini_section(section, buffer, oldlen, filename);
+                ret = construct_redirected_ini_section(section, buffer, oldlen, filename);
+                if (!ret)
+                    ret = GetPrivateProfileStringA(section, entry, def_val, buffer, len, filename);
+                return ret;
             }
             if (ret != size - 2) break;
             /* overflow, try again */


### PR DESCRIPTION
… isn't.  partially fixes procomm plus 3 installer