### PR TITLE
only set the idle event in createdialog when the dialog is modal

### DIFF
--- a/user/dialog.c
+++ b/user/dialog.c
@@ -688,9 +688,9 @@ static HWND DIALOG_CreateIndirect16(HINSTANCE16 hInst, SEGPTR dlgTemplate16,
     DLGPROC proc = allocate_proc_thunk(paramd, DlgProc_Thunk);
     paramd->dlgProc = dlgProc;
     ReleaseThunkLock(&count);
-    SetEvent(kernel_get_thread_data()->idle_event);
     if (modal)
     {
+        SetEvent(kernel_get_thread_data()->idle_event);
         result = (HWND)DialogBoxIndirectParamA(
             UlongToHandle(HandleToUlong(hInst32) | (is_reactos() ? 0xfefe0000 : 0)),
             template32,


### PR DESCRIPTION
fixes crash opening fax inbox in procomm plus 3