### PR TITLE
don't copy the empty environment var

### DIFF
--- a/krnl386/task.c
+++ b/krnl386/task.c
@@ -1869,7 +1869,7 @@ DWORD WINAPI GetAppCompatFlags16( HTASK16 hTask )
 
 const char *env_var_limitation[] =
 {
-    "", "COMSPEC", "TEMP", "TMP", "PATH"
+    "COMSPEC", "TEMP", "TMP", "PATH"
 };
 BOOL env_var_limit(const char *v)
 {


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/416