### PR TITLE
Fix a crash due to the access violation when DialogBoxIndirectParamA is called

### DIFF
--- a/user/dialog.c
+++ b/user/dialog.c
@@ -401,6 +401,7 @@ static BOOL DIALOG_CreateControls16Ex(HWND hwnd, LPCSTR template,
 	INT items = dlgTemplate->nbItems;
 	dlgItemTemplate32 = (BYTE*) (((DWORD)dlgItemTemplate32 + 3) & ~((DWORD)3));
 	WORD *dlgItemTemplatew;
+	BOOL rscIdWorkaround;
 	TRACE(" BEGIN\n");
 	while (items--)
 	{
@@ -416,13 +417,16 @@ static BOOL DIALOG_CreateControls16Ex(HWND hwnd, LPCSTR template,
 		dlgItemTemplatew = (WORD*)(dlgItemTemplate32 + 1);
         info.className = win32classname(hInst, info.className);
 		copy_widestr(info.className, &dlgItemTemplatew);
+        rscIdWorkaround = FALSE;
         if (!HIWORD(info.windowName))
         {
             char buffer[512];
             if (((dlgItemTemplate32->style & 0xF) == SS_ICON || (dlgItemTemplate32->style & 0xF) == SS_BITMAP) && stricmp(info.className, "STATIC") == 0)
             {
-                sprintf(buffer, "#%d", (int)info.windowName);
-                copy_widestr(buffer, &dlgItemTemplatew);
+                rscIdWorkaround = TRUE;
+                *dlgItemTemplatew++ = 0x0000;
+                *dlgItemTemplatew++ = sizeof(WORD) * 2;
+                *dlgItemTemplatew++ = LOWORD(info.windowName);
             }
             else
             {
@@ -444,7 +448,7 @@ static BOOL DIALOG_CreateControls16Ex(HWND hwnd, LPCSTR template,
             *((LPCVOID*)dlgItemTemplatew) = MAKESEGPTR(SELECTOROF(base16), OFFSETOF(base16) + (WORD)((SIZE_T)info.data - base32));
 			dlgItemTemplatew += 2;
 		}
-		else
+		else if (!rscIdWorkaround)
 		{
 			*dlgItemTemplatew++ = 0;
 		}

--- a/user/message.c
+++ b/user/message.c
@@ -4388,17 +4388,21 @@ LRESULT CALLBACK WndProcRetHook(int code, WPARAM wParam, LPARAM lParam)
                     {
                     case SS_ICON:
                     {
+                        char rsc_id[32];
+                        sprintf(rsc_id, "#%d", (int)cs->lpCreateParams);
                         SetWindowTextA(hwnd, "");
-                        HICON16 icon = LoadIcon16(HINSTANCE_16(cs->hInstance), cs->lpszName);
-                        if (!icon) icon = LoadCursor16(HINSTANCE_16(cs->hInstance), cs->lpszName);
+                        HICON16 icon = LoadIcon16(HINSTANCE_16(cs->hInstance), rsc_id);
+                        if (!icon) icon = LoadCursor16(HINSTANCE_16(cs->hInstance), rsc_id);
                         if (icon) wow_handlers32.static_proc(hwnd, STM_SETIMAGE, IMAGE_ICON,
                             (LPARAM)get_icon_32(icon), FALSE);
                         break;
                     }
                     case SS_BITMAP:
                     {
+                        char rsc_id[32];
+                        sprintf(rsc_id, "#%d", (int)cs->lpCreateParams);
                         SetWindowTextA(hwnd, "");
-                        HBITMAP16 bitmap = LoadBitmap16(HINSTANCE_16(cs->hInstance), cs->lpszName);
+                        HBITMAP16 bitmap = LoadBitmap16(HINSTANCE_16(cs->hInstance), rsc_id);
                         if (bitmap) wow_handlers32.static_proc(hwnd, STM_SETIMAGE, IMAGE_BITMAP,
                             (LPARAM)HBITMAP_32(bitmap), FALSE);
                         break;


### PR DESCRIPTION
Hello.

I found the access violation is occurred when DialogBoxIndirectParamA() is called in DIALOG_CreateIndirect16() if icon or bitmap resource is exists in the dialog template.
According to stack trace when the access violation is occurred, it seems to try to access resources which is exist in NE file from PE while DialogBoxIndirectParamA() is calling.

To avoid this, I add a workaround that uses the extra data instead of the resource name directly. After apply this fix, DialogBoxIndirectParamA() is working correctly without the access violation as below:

![image](https://user-images.githubusercontent.com/11531985/63733284-aa652500-c8b2-11e9-90a2-cc0e84f2b4a9.png)
