### PR TITLE
openfile can return handles that appear to be lzhandles so make it ex…

### DIFF
--- a/lzexpand/lzexpand.c
+++ b/lzexpand/lzexpand.c
@@ -111,15 +111,17 @@ LONG WINAPI LZCopy16( HFILE16 src, HFILE16 dest )
 }
 
 
+HFILE WINAPI LZOpenFile( LPSTR fn, LPOFSTRUCT ofs, WORD mode, BOOL *lzhandle );
 /***********************************************************************
  *           LZOpenFile   (LZEXPAND.2)
  */
 HFILE16 WINAPI LZOpenFile16(LPSTR fn, LPOFSTRUCT ofs, UINT16 mode)
 {
-	HFILE hfret = LZOpenFileA(fn, ofs, mode);
+	BOOL lzhandle;
+	HFILE hfret = LZOpenFile(fn, ofs, mode, &lzhandle);
 	/* return errors and LZ handles unmodified */
 	if ((INT)hfret < 0) return hfret;
-	if (IS_LZ_HANDLE(hfret)) return hfret;
+	if (lzhandle) return hfret;
 	/* but allocate a dos handle for 'normal' files */
 	return Win32HandleToDosFileHandle((HANDLE)hfret);
 }

--- a/lzexpand/lzexpand.c
+++ b/lzexpand/lzexpand.c
@@ -111,14 +111,14 @@ LONG WINAPI LZCopy16( HFILE16 src, HFILE16 dest )
 }
 
 
-HFILE WINAPI LZOpenFile( LPSTR fn, LPOFSTRUCT ofs, WORD mode, BOOL *lzhandle );
+HFILE WINAPI LZOpenFileA16( LPSTR fn, LPOFSTRUCT ofs, WORD mode, BOOL *lzhandle );
 /***********************************************************************
  *           LZOpenFile   (LZEXPAND.2)
  */
 HFILE16 WINAPI LZOpenFile16(LPSTR fn, LPOFSTRUCT ofs, UINT16 mode)
 {
 	BOOL lzhandle;
-	HFILE hfret = LZOpenFile(fn, ofs, mode, &lzhandle);
+	HFILE hfret = LZOpenFileA16(fn, ofs, mode, &lzhandle);
 	/* return errors and LZ handles unmodified */
 	if ((INT)hfret < 0) return hfret;
 	if (lzhandle) return hfret;

--- a/lzexpand/wine_lzexpand.c
+++ b/lzexpand/wine_lzexpand.c
@@ -531,10 +531,11 @@ static LPSTR LZEXPAND_MangleName( LPCSTR fn )
  *
  * Opens a file. If not compressed, open it as a normal file.
  */
-HFILE WINAPI LZOpenFileA( LPSTR fn, LPOFSTRUCT ofs, WORD mode )
+HFILE WINAPI LZOpenFile( LPSTR fn, LPOFSTRUCT ofs, WORD mode, BOOL *lzhandle )
 {
 	HFILE	fd,cfd;
 	BYTE    ofs_cBytes = ofs->cBytes;
+	*lzhandle = FALSE;
 
 	TRACE("(%s,%p,%d)\n",fn,ofs,mode);
 	/* 0x70 represents all OF_SHARE_* flags, ignore them for the check */
@@ -551,26 +552,11 @@ HFILE WINAPI LZOpenFileA( LPSTR fn, LPOFSTRUCT ofs, WORD mode )
 		return fd;
 	if (fd==HFILE_ERROR)
 		return HFILE_ERROR;
+	*lzhandle = TRUE;
 	cfd=LZInit(fd);
 	if ((INT)cfd <= 0) return fd;
 	return cfd;
 }
-
-
-/***********************************************************************
- *           LZOpenFileW   (KERNEL32.@)
- */
-HFILE WINAPI LZOpenFileW( LPWSTR fn, LPOFSTRUCT ofs, WORD mode )
-{
-    HFILE ret;
-    DWORD len = WideCharToMultiByte( CP_ACP, 0, fn, -1, NULL, 0, NULL, NULL );
-    LPSTR xfn = HeapAlloc( GetProcessHeap(), 0, len );
-    WideCharToMultiByte( CP_ACP, 0, fn, -1, xfn, len, NULL, NULL );
-    ret = LZOpenFileA(xfn,ofs,mode);
-    HeapFree( GetProcessHeap(), 0, xfn );
-    return ret;
-}
-
 
 /***********************************************************************
  *           LZClose   (KERNEL32.@)

--- a/lzexpand/wine_lzexpand.c
+++ b/lzexpand/wine_lzexpand.c
@@ -50,6 +50,7 @@
 
 #include "wine/unicode.h"
 #include "wine/debug.h"
+#include "wine/winbase16.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(file);
 
@@ -572,6 +573,7 @@ void WINAPI LZClose( HFILE fd )
             HeapFree( GetProcessHeap(), 0, lzs->get );
             CloseHandle( LongToHandle(lzs->realfd) );
             lzstates[fd - LZ_MIN_HANDLE] = NULL;
+            DisposeLZ32Handle(lzs->realfd);
             HeapFree( GetProcessHeap(), 0, lzs );
         }
 }

--- a/lzexpand/wine_lzexpand.c
+++ b/lzexpand/wine_lzexpand.c
@@ -531,7 +531,7 @@ static LPSTR LZEXPAND_MangleName( LPCSTR fn )
  *
  * Opens a file. If not compressed, open it as a normal file.
  */
-HFILE WINAPI LZOpenFile( LPSTR fn, LPOFSTRUCT ofs, WORD mode, BOOL *lzhandle )
+HFILE WINAPI LZOpenFileA16( LPSTR fn, LPOFSTRUCT ofs, WORD mode, BOOL *lzhandle )
 {
 	HFILE	fd,cfd;
 	BYTE    ofs_cBytes = ofs->cBytes;


### PR DESCRIPTION
…plicit in the return from lzopenfile

partially fixes wordstar 1.5 installer

Edit: the later commit makes the installer fully work other then some harmless errors with system dlls