### PR TITLE
check for ')' after spaces so buffer isn't overrun

### DIFF
--- a/user/dde.c
+++ b/user/dde.c
@@ -519,6 +519,8 @@ static DWORD parse_dde_command(HSZ hszTopic, WCHAR *command)
                         command++;
                         if (!(p = strchrW(command, '"'))) goto error;
                     }
+                    else if (*command == ')')
+                        break;
                     else
                     {
                         if (!(p = strpbrkW(command, param_end))) goto error;


### PR DESCRIPTION
fixes borland office installer start menu creation 