### PR TITLE
dos attributes are contained only in the lower byte so clear the top …

### DIFF
--- a/krnl386/int21.c
+++ b/krnl386/int21.c
@@ -2108,6 +2108,7 @@ static BOOL INT21_FileAttributes( CONTEXT *context,
             return FALSE;
         else
         {
+            result &= 0xff;
             SET_CX( context, (WORD)result );
             if (!islong)
                 SET_AX( context, (WORD)result ); /* DR DOS */


### PR DESCRIPTION
…byte

maybe fixes https://github.com/otya128/winevdm/issues/450