### PR TITLE
if arg equals hwnd set arg to 0

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -2835,6 +2835,8 @@ LRESULT def_frame_proc_callback(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp, LRESU
 {
     DWORD count;
     ReleaseThunkLock(&count);
+    if (hwnd == (HWND)arg)
+        arg = NULL;
     *result = DefFrameProcA(hwnd, (HWND)arg, msg, wp, lp);
     RestoreThunkLock(count);
     return *result;


### PR DESCRIPTION
Paradox and Database Desktop from Borland Office 2.0 set DefFrameProcA hWndMDIClient to the same as hWnd when replying to messages in CreateWindow.  DefFrameProcA return 0 which causes the window creation to fail.  Clearing hWndMDIClient when it equals hWnd makes the message be sent to DefWindowProc which returns the correct value.

fixes https://github.com/otya128/winevdm/issues/461