### PR TITLE
translate window handle for wintee32 from msvc 1.5

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -1988,7 +1988,7 @@ LRESULT WINPROC_CallProc32ATo16( winproc_callback16_t callback, HWND hwnd, UINT 
             cds.cbData = cds32->cbData;
             cds.lpData = MapLS( cds32->lpData );
             lParam = MapLS( &cds );
-            ret = callback( HWND_16(hwnd), msg, wParam, lParam, result, arg );
+            ret = callback( HWND_16(hwnd), msg, HWND_16(wParam), lParam, result, arg );
             UnMapLS( lParam );
             UnMapLS( cds.lpData );
         }


### PR DESCRIPTION
Wintee32 from msvc 1.5 gets passed a window handle on it's command line.  NTVDM just truncated the hwnd to 16 bits then oring it with 0xffff0000 produced (and still does) a working handle.  That, of course, might change in the future so it's better for winevdm to not use that but makes this workaround necessary.  IMO it's an important enough program to justify a specific fix.