### PR TITLE
clear dx in globalfree

### DIFF
--- a/krnl386/global.c
+++ b/krnl386/global.c
@@ -759,7 +759,7 @@ DWORD WINAPI WIN16_GlobalFlags16(HGLOBAL16 handle)
     CURRENT_STACK16->es = 0;
     return MAKELONG(GlobalFlags16(handle), GlobalHandleToSel16(handle));
 }
-HGLOBAL16 WINAPI WIN16_GlobalFree16(HGLOBAL16 handle)
+DWORD WINAPI WIN16_GlobalFree16(HGLOBAL16 handle)
 {
     CURRENT_STACK16->es = 0;
     return GlobalFree16(handle);

--- a/krnl386/krnl386.exe16.spec
+++ b/krnl386/krnl386.exe16.spec
@@ -17,7 +17,7 @@
 14  pascal LocalNotify(long) LocalNotify16
 15  pascal -register GlobalAlloc(word long) WIN16_GlobalAlloc16
 16  pascal -ret16 GlobalReAlloc(word long word) WIN16_GlobalReAlloc16
-17  pascal -ret16 GlobalFree(word) WIN16_GlobalFree16
+17  pascal GlobalFree(word) WIN16_GlobalFree16
 18  pascal GlobalLock(word) WIN16_GlobalLock16
 19  pascal GlobalUnlock(word) WIN16_GlobalUnlock16
 20  pascal GlobalSize(word) WIN16_GlobalSize16


### PR DESCRIPTION
Fixes vb 1.0 build exe and verified that ntvdm does the same.