### PR TITLE
fix em_getsel

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -2217,6 +2217,8 @@ LRESULT WINPROC_CallProc32ATo16( winproc_callback16_t callback, HWND hwnd, UINT 
         ret = callback(HWND_16(hwnd), msg + EM_GETSEL16 - EM_GETSEL, wParam, (LPARAM)MapLS(lParam), result, arg);
         break;
     case EM_GETSEL:
+        ret = callback(HWND_16(hwnd), msg + EM_GETSEL16 - EM_GETSEL, 0, 0, result, arg);
+        break;
     case EM_SETRECT:
     case EM_SETRECTNP:
     case EM_SCROLL:


### PR DESCRIPTION
One program tries to use lparam as a pointer of the wrong type.  Since the 16bit version of EM_GETSEL isn't documented to put anything valid into lparam and any value is zeroed when passed to the 32bit handler and thus are lost anyway make them zero before calling the 16bit wndproc.