### PR TITLE
forward opendriver16 to drvopen16 and fake success if a 32bit driver …

### DIFF
--- a/mmsystem/driver.c
+++ b/mmsystem/driver.c
@@ -285,9 +285,23 @@ HDRVR16 WINAPI DrvOpen16(LPCSTR lpDriverName, LPCSTR lpSectionName, LPARAM lPara
 				 drvName, sizeof(drvName), "SYSTEM.INI") > 0) {
 	lpDrv = DRIVER_TryOpenDriver16(drvName, lParam2);
     }
-    if (!lpDrv) {
-	TRACE("Failed to open driver %s from system.ini file, section %s\n", debugstr_a(lpDriverName), debugstr_a(lpSectionName));
-	return 0;
+    if (!lpDrv)
+    {
+        if (!stricmp(lpSectionName, "drivers"))
+        {
+            // if 32bit driver exists pretend success
+            if (GetPrivateProfileStringA("drivers32", lpDriverName, "",
+		        		 drvName, sizeof(drvName), "SYSTEM.INI") > 0)
+                return 0xdead;
+        }
+        else if (!stricmp(lpSectionName, "mci"))
+        {
+            if (GetPrivateProfileStringA("mci32", lpDriverName, "",
+		        		 drvName, sizeof(drvName), "SYSTEM.INI") > 0)
+                return 0xdead;
+        }
+        TRACE("Failed to open driver %s from system.ini file, section %s\n", debugstr_a(lpDriverName), debugstr_a(lpSectionName));
+        return 0;
     }
  the_end:
     TRACE("=> %04x / %p\n", lpDrv->hDriver16, lpDrv);

--- a/mmsystem/mmsystem.def
+++ b/mmsystem/mmsystem.def
@@ -4,3 +4,4 @@ LIBRARY mmsystem.dll16
 
 EXPORTS
   _wine_spec_dos_header @1 DATA
+  DrvOpen16

--- a/user/user.c
+++ b/user/user.c
@@ -1852,8 +1852,24 @@ LRESULT WINAPI SendDriverMessage16(HDRVR16 hDriver, UINT16 msg, LPARAM lParam1,
  */
 HDRVR16 WINAPI OpenDriver16(LPCSTR lpDriverName, LPCSTR lpSectionName, LPARAM lParam2)
 {
-    FIXME( "(%s, %s, %08lx): stub\n", debugstr_a(lpDriverName), debugstr_a(lpSectionName), lParam2);
-    return 0;
+    TRACE( "(%s, %s, %08lx): stub\n", debugstr_a(lpDriverName), debugstr_a(lpSectionName), lParam2);
+    static HDRVR16 (WINAPI *DrvOpen16)(LPCSTR, LPCSTR, LPARAM) = NULL;
+    if (!DrvOpen16)
+    {
+        HMODULE mmsystem = GetModuleHandleA("mmsystem.dll16");
+        if (!mmsystem)
+        {
+            ERR("mmsystem not loaded\n");
+            return 0;
+        }
+        (FARPROC)DrvOpen16 = GetProcAddress(mmsystem, "DrvOpen16");
+        if (!DrvOpen16)
+        {
+            ERR("DrvOpen16 load error\n");
+            return 0;
+        }
+    }
+    return DrvOpen16(lpDriverName, lpSectionName, lParam2);
 }
 
 

--- a/user/user.c
+++ b/user/user.c
@@ -1862,7 +1862,7 @@ HDRVR16 WINAPI OpenDriver16(LPCSTR lpDriverName, LPCSTR lpSectionName, LPARAM lP
             ERR("mmsystem not loaded\n");
             return 0;
         }
-        ((FARPROC)DrvOpen16) = GetProcAddress(mmsystem, "DrvOpen16");
+        DrvOpen16 = (HDRVR16 (WINAPI *)(LPCSTR, LPCSTR, LPARAM))GetProcAddress(mmsystem, "DrvOpen16");
         if (!DrvOpen16)
         {
             ERR("DrvOpen16 load error\n");

--- a/user/user.c
+++ b/user/user.c
@@ -1862,7 +1862,7 @@ HDRVR16 WINAPI OpenDriver16(LPCSTR lpDriverName, LPCSTR lpSectionName, LPARAM lP
             ERR("mmsystem not loaded\n");
             return 0;
         }
-        (FARPROC)DrvOpen16 = GetProcAddress(mmsystem, "DrvOpen16");
+        ((FARPROC)DrvOpen16) = GetProcAddress(mmsystem, "DrvOpen16");
         if (!DrvOpen16)
         {
             ERR("DrvOpen16 load error\n");


### PR DESCRIPTION
…or codec exists.

partially fixes Beyond Planet Earth which checks vfw is installed by opening and closing the drivers. 