### PR TITLE
add setpalletetranslate stub

### DIFF
--- a/display/display.c
+++ b/display/display.c
@@ -93,3 +93,9 @@ VOID WINAPI UserRepaintDisable16( BOOL16 disable )
 {
     FIXME("stub\n");
 }
+
+WORD WINAPI SetPaletteTranslate16( WORD wNumEntries, LPBYTE lpTranslate)
+{
+    WARN("stub\n");
+    return 0;
+}

--- a/display/display.drv16.spec
+++ b/display/display.drv16.spec
@@ -23,7 +23,7 @@
 # ATI driver exports
 22 stub SetPalette
 23 stub GetPalette
-24 stub SetPaletteTranslate
+24 pascal -ret16 SetPaletteTranslate(word ptr) SetPaletteTranslate16
 25 stub GetPaletteTranslate
 26 stub UpdateColors
 27 stub StretchBlt


### PR DESCRIPTION
make quicktime sort of work, it seems video is limited to 65536 bytes per frame and 32bit color mode hits that limit very quickly.