### PR TITLE
zero the openfilename struct so if compiled with vista+ headers the f…

### DIFF
--- a/winhlp32/winhelp.c
+++ b/winhlp32/winhelp.c
@@ -179,6 +179,7 @@ BOOL WINHELP_GetOpenFileName(LPSTR lpszFile, int len)
     CHAR szzFilter[2 * MAX_STRING_LEN + 100];
     LPSTR p = szzFilter;
 
+    memset(&openfilename, 0, sizeof(OPENFILENAMEA));
     WINE_TRACE("()\n");
 
     LoadStringA(Globals.hInstance, STID_HELP_FILES_HLP, p, MAX_STRING_LEN);


### PR DESCRIPTION
…lagsex member is set to 0 so making the dialog style consistent