### PR TITLE
Dccache

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -1947,12 +1947,6 @@ DWORD WINAPI GetDCOrg16( HDC16 hdc )
 INT16 WINAPI GetDeviceCaps16( HDC16 hdc, INT16 cap )
 {
     HDC hdc32 = HDC_32(hdc);
-    BOOL release = FALSE;
-    if (!GetObjectType(hdc32)) // Assume object was already released
-    {
-        release = TRUE;
-        hdc32 = GetDC(NULL);
-    }
     INT16 ret = GetDeviceCaps( hdc32, cap );
     /* some apps don't expect -1 and think it's a B&W screen */
     if (krnl386_get_compat_mode("256color") && (GetDeviceCaps(hdc32, TECHNOLOGY) == DT_RASDISPLAY))
@@ -1974,8 +1968,6 @@ INT16 WINAPI GetDeviceCaps16( HDC16 hdc, INT16 cap )
         }
     }
     else if ((cap == NUMCOLORS) && (ret == -1)) ret = 2048;
-    if (release)
-        ReleaseDC(NULL, hdc32);
     return ret;
 }
 

--- a/user/window.c
+++ b/user/window.c
@@ -1156,6 +1156,8 @@ INT16 WINAPI ReleaseDC16( HWND16 hwnd, HDC16 hdc )
 {
     if (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a)
     {
+        if (!hwnd)
+            hwnd = HWND_16(GetDesktopWindow());
         if (WindowFromDC(HDC_32(hdc)) != HWND_32(hwnd))
             return 0;
         if (dcc.dcs[dcc.next])

--- a/user/window.c
+++ b/user/window.c
@@ -27,6 +27,12 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(win);
 
+struct {
+    int next;
+    HDC16 dcs[5];
+    HWND16 wnds[5];
+} dcc = {0};
+
 /* Workaround for ReactOS */
 BOOL is_reactos()
 {
@@ -1148,6 +1154,22 @@ HDC16 WINAPI GetWindowDC16( HWND16 hwnd )
  */
 INT16 WINAPI ReleaseDC16( HWND16 hwnd, HDC16 hdc )
 {
+    if (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a)
+    {
+        if (dcc.dcs[dcc.next])
+        {
+            HDC16 oldhdc = dcc.dcs[dcc.next];
+            HDC16 oldhwnd = dcc.wnds[dcc.next];
+            if(ReleaseDC( WIN_Handle32(oldhwnd), HDC_32(oldhdc) ) || !IsWindow(HWND_32(oldhwnd)))
+            {
+                K32WOWHandle16DestroyHint(HDC_32(oldhdc), WOW_TYPE_HDC);
+            }
+        }
+        dcc.dcs[dcc.next] = hdc;
+        dcc.wnds[dcc.next] = hwnd;
+        dcc.next = (dcc.next + 1) % 5;
+        return GetObjectType(HDC_32(hdc)) == OBJ_DC;
+    }
     INT16 result = (INT16)ReleaseDC( WIN_Handle32(hwnd), HDC_32(hdc) );
     if (result)
     {

--- a/user/window.c
+++ b/user/window.c
@@ -1156,7 +1156,7 @@ INT16 WINAPI ReleaseDC16( HWND16 hwnd, HDC16 hdc )
 {
     if (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a)
     {
-        if (!GetObjectType(HDC_32(hdc)) == OBJ_DC)
+        if (WindowFromDC(HDC_32(hdc)) != HWND_32(hwnd))
             return 0;
         if (dcc.dcs[dcc.next])
         {

--- a/user/window.c
+++ b/user/window.c
@@ -1156,6 +1156,8 @@ INT16 WINAPI ReleaseDC16( HWND16 hwnd, HDC16 hdc )
 {
     if (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a)
     {
+        if (!GetObjectType(HDC_32(hdc)) == OBJ_DC)
+            return 0;
         if (dcc.dcs[dcc.next])
         {
             HDC16 oldhdc = dcc.dcs[dcc.next];
@@ -1168,7 +1170,7 @@ INT16 WINAPI ReleaseDC16( HWND16 hwnd, HDC16 hdc )
         dcc.dcs[dcc.next] = hdc;
         dcc.wnds[dcc.next] = hwnd;
         dcc.next = (dcc.next + 1) % 5;
-        return GetObjectType(HDC_32(hdc)) == OBJ_DC;
+        return 1;
     }
     INT16 result = (INT16)ReleaseDC( WIN_Handle32(hwnd), HDC_32(hdc) );
     if (result)


### PR DESCRIPTION
Since windows 3.0 could only have 5 display dcs at a time, caching 5 ought to be enough.  Also revert https://github.com/otya128/winevdm/pull/300 which is not needed after this.

fixes https://github.com/otya128/winevdm/issues/505