### PR TITLE
save 32bit global handles so ddeml properly ends transactions

### DIFF
--- a/ddeml/ddeml.c
+++ b/ddeml/ddeml.c
@@ -34,6 +34,7 @@
 #include "wownt32.h"
 #include "dde.h"
 #include "ddeml.h"
+#include "winuser.h"
 #include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(ddeml);
@@ -395,8 +396,16 @@ HDDEDATA WINAPI DdeCreateDataHandle16(DWORD idInst, LPBYTE pSrc, DWORD cb,
  */
 HSZ WINAPI DdeCreateStringHandle16(DWORD idInst, LPCSTR str, INT16 codepage)
 {
-    if  (codepage != CP_WINANSI)
-        WARN("Codepage %x supplied but only CP_WINANSI is supported\n", codepage);
+    if (codepage != CP_WINANSI)
+    {
+        if (!codepage || (codepage == GetKBCodePage()))
+            WARN("Codepage %x supplied but only CP_WINANSI is supported\n", codepage);
+        else
+        {
+            ERR("Invalid codepage %x\n", codepage);
+            return DMLERR_INVALIDPARAMETER;
+        }
+    }
   
     return DdeCreateStringHandleA(idInst, str, CP_WINANSI);
 }

--- a/ddeml/ddeml.c
+++ b/ddeml/ddeml.c
@@ -102,7 +102,7 @@ static HDDEDATA	CALLBACK WDML_InvokeCallback16(DWORD pfn16, UINT uType, UINT uFm
     DWORD               d1 = 0;
     HDDEDATA            ret;
     CONVCONTEXT16       cc16;
-    WORD args[16];
+    WORD args[14];
 
     switch (uType)
     {
@@ -118,10 +118,8 @@ static HDDEDATA	CALLBACK WDML_InvokeCallback16(DWORD pfn16, UINT uType, UINT uFm
         d1 = dwData1;
         break;
     }
-    args[15] = HIWORD(uType);
-    args[14] = LOWORD(uType);
-    args[13] = HIWORD(uFmt);
-    args[12] = LOWORD(uFmt);
+    args[13] = uType;
+    args[12] = uFmt;
     args[11] = HIWORD(hConv);
     args[10] = LOWORD(hConv);
     args[9]  = HIWORD(hsz1);
@@ -397,15 +395,10 @@ HDDEDATA WINAPI DdeCreateDataHandle16(DWORD idInst, LPBYTE pSrc, DWORD cb,
  */
 HSZ WINAPI DdeCreateStringHandle16(DWORD idInst, LPCSTR str, INT16 codepage)
 {
-    if  (codepage)
-    {
-        return DdeCreateStringHandleA(idInst, str, codepage);
-    }
-    else
-    {
-        TRACE("Default codepage supplied\n");
-        return DdeCreateStringHandleA(idInst, str, CP_WINANSI);
-    }
+    if  (codepage != CP_WINANSI)
+        WARN("Codepage %x supplied but only CP_WINANSI is supported\n", codepage);
+  
+    return DdeCreateStringHandleA(idInst, str, CP_WINANSI);
 }
 
 /*****************************************************************

--- a/krnl386/global.c
+++ b/krnl386/global.c
@@ -58,7 +58,8 @@ typedef struct
     DWORD     dib_avail_size;
     WORD      wSeg;
     WORD      wType;
-    BYTE      pad[0x10 - 4 - 2 - 2];     /* win31 GLOBALARENA size = 0x20 */
+    HGLOBAL   orig_hndl;
+    BYTE      pad[0x10 - 4 - 2 - 2 - 4];     /* win31 GLOBALARENA size = 0x20 */
 } GLOBALARENA;
 
   /* Flags definitions */
@@ -186,6 +187,7 @@ HGLOBAL16 GLOBAL_CreateBlock( WORD flags, void *ptr, DWORD size,
     pArena->wSeg = 0;
     pArena->wType = GT_UNKNOWN;
     pArena->flags = flags & GA_MOVEABLE;
+    pArena->orig_hndl = NULL;
     if (flags & GMEM_DISCARDABLE) pArena->flags |= GA_DISCARDABLE;
     if (flags & GMEM_DDESHARE) pArena->flags |= GA_IPCSHARE;
     if (!(selflags & (WINE_LDT_FLAGS_CODE^WINE_LDT_FLAGS_DATA))) pArena->flags |= GA_DGROUP;
@@ -298,6 +300,16 @@ void GLOBAL_SetSeg(HGLOBAL16 hg, WORD wSeg, WORD type)
 {
     GET_ARENA_PTR(hg)->wSeg = wSeg;
     GET_ARENA_PTR(hg)->wType = type;
+}
+
+HGLOBAL GLOBAL_GetOrig(HGLOBAL16 hg)
+{
+    return GET_ARENA_PTR(hg)->orig_hndl;
+}
+
+void GLOBAL_SetOrig(HGLOBAL16 hg16, HGLOBAL hg)
+{
+    GET_ARENA_PTR(hg16)->orig_hndl = hg;
 }
 
 /***********************************************************************

--- a/krnl386/krnl386.def
+++ b/krnl386/krnl386.def
@@ -233,3 +233,5 @@ EXPORTS
   TaskSetCSIP16
   TaskGetCSIP16
   TaskSwitch16
+  GLOBAL_GetOrig
+  GLOBAL_SetOrig

--- a/krnl386/krnl386.exe16.spec
+++ b/krnl386/krnl386.exe16.spec
@@ -788,3 +788,5 @@
 @ stdcall -arch=win32 TaskGetCSIP16(long)
 @ stdcall -arch=win32 TaskSwitch16(long long)
 @ stdcall -arch=win32 AllocDStoCSAlias16(long)
+@ cdecl -arch=win32 GLOBAL_GetOrig(long)
+@ cdecl -arch=win32 GLOBAL_SetOrig(long long)

--- a/user/message.c
+++ b/user/message.c
@@ -778,7 +778,12 @@ static UINT_PTR convert_handle_16_to_32(HANDLE16 src, unsigned int flags)
     UINT        sz = GlobalSize16(src);
     LPSTR       ptr16, ptr32;
 
-    if (!(dst = GlobalAlloc(flags, sz)))
+    if (dst = GLOBAL_GetOrig(src))
+    {
+        if (GlobalSize(dst) != sz)
+            dst = GlobalReAlloc(dst, sz, 0);
+    }
+    else if (!(dst = GlobalAlloc(flags, sz)))
         return 0;
     ptr16 = GlobalLock16(src);
     ptr32 = GlobalLock(dst);
@@ -802,6 +807,7 @@ static HANDLE16 convert_handle_32_to_16(UINT_PTR src, unsigned int flags)
     if (ptr16 != NULL && ptr32 != NULL) memcpy(ptr16, ptr32, sz);
     GlobalUnlock((HANDLE)src);
     GlobalUnlock16(dst);
+    GLOBAL_SetOrig(dst, (HANDLE)src);
 
     return dst;
 }


### PR DESCRIPTION
force DdeCreateStringHandle codepage to CP_WINANSI because win32 ddeml doesn't support any other non unicode codepage
fix 16bit ddeml callback arguments

fixes hp12c12 installer (https://github.com/otya128/winevdm/issues/334)