### PR TITLE
force ws_caption for overlapped windows

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -3026,6 +3026,9 @@ HWND16 WINAPI CreateWindowEx16( DWORD exStyle, LPCSTR className,
         cs.cy = CW_USEDEFAULT;
     }
 
+    if (!(style & (WS_POPUP | WS_CHILD)))
+        style |= WS_CAPTION;
+
     /* Create the window */
 
     cs.lpCreateParams = data;

--- a/user/window.c
+++ b/user/window.c
@@ -3017,17 +3017,22 @@ HWND16 WINAPI CreateWindowEx16( DWORD exStyle, LPCSTR className,
     cs.cx = (width == CW_USEDEFAULT16) ? CW_USEDEFAULT : (INT)width;
     cs.cy = (height == CW_USEDEFAULT16) ? CW_USEDEFAULT : (INT)height;
 
-    // make windows 1.0 programs appear in a usable window
-    if (IsOldWindowsTask(GetCurrentTask()) && !(style & WS_CHILD) && (!cs.cx || !cs.cy))
-    {
-        cs.x = CW_USEDEFAULT;
-        cs.y = CW_USEDEFAULT;
-        cs.cx = CW_USEDEFAULT;
-        cs.cy = CW_USEDEFAULT;
-    }
-
     if (!(style & (WS_POPUP | WS_CHILD | WS_DLGFRAME)))
         style |= WS_CAPTION;
+
+    // make windows 1.0 programs appear in a usable window
+    if ((GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x200) && !(style & WS_CHILD))
+    {
+        if (!cs.cx || !cs.cy)
+        {
+            cs.x = CW_USEDEFAULT;
+            cs.y = CW_USEDEFAULT;
+            cs.cx = CW_USEDEFAULT;
+            cs.cy = CW_USEDEFAULT;
+        }
+        if ((style & (WS_CAPTION | WS_SIZEBOX)) == (WS_CAPTION | WS_SIZEBOX))
+            style |= WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+    }
 
     /* Create the window */
 

--- a/user/window.c
+++ b/user/window.c
@@ -3026,7 +3026,7 @@ HWND16 WINAPI CreateWindowEx16( DWORD exStyle, LPCSTR className,
         cs.cy = CW_USEDEFAULT;
     }
 
-    if (!(style & (WS_POPUP | WS_CHILD)))
+    if (!(style & (WS_POPUP | WS_CHILD | WS_DLGFRAME)))
         style |= WS_CAPTION;
 
     /* Create the window */

--- a/user/window.c
+++ b/user/window.c
@@ -3021,7 +3021,7 @@ HWND16 WINAPI CreateWindowEx16( DWORD exStyle, LPCSTR className,
         style |= WS_CAPTION;
 
     // make windows 1.0 programs appear in a usable window
-    if ((GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x200) && !(style & WS_CHILD))
+    if ((GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x201) && !(style & WS_CHILD))
     {
         if (!cs.cx || !cs.cy)
         {


### PR DESCRIPTION
Windows makes a title bar for non-popup windows anyway but if it isn't explicit it gets a themed title.   
fixes https://github.com/otya128/winevdm/issues/293
The last commit fixes https://github.com/otya128/winevdm/issues/251