### PR TITLE
check for the mdi system menu icon in drawmenubar which will make sur…

### DIFF
--- a/user/user.c
+++ b/user/user.c
@@ -2952,14 +2952,6 @@ BOOL16 WINAPI InsertMenu16( HMENU16 hMenu, UINT16 pos, UINT16 flags,
     if (IS_MENU_STRING_ITEM(flags) && data)
         return InsertMenuA( menu, pos32, flags, id32, MapSL(data) );
     ret = InsertMenuA( menu, pos32, flags, id32, (LPSTR)data );
-    if ((flags & MF_BITMAP) && (flags & MF_POPUP) && !pos)
-    {
-        MENUITEMINFOA mii = {0};
-        mii.cbSize = sizeof(MENUITEMINFOA);
-        mii.hbmpItem = HBMMENU_SYSTEM;
-        mii.fMask = MIIM_BITMAP;
-        SetMenuItemInfoA(menu, 0, TRUE, &mii);
-    }
     return ret;
 }
 

--- a/user/window.c
+++ b/user/window.c
@@ -1778,7 +1778,25 @@ BOOL16 WINAPI SetMenu16( HWND16 hwnd, HMENU16 hMenu )
  */
 void WINAPI DrawMenuBar16( HWND16 hwnd )
 {
-    DrawMenuBar( WIN_Handle32(hwnd) );
+    HWND hwnd32 = HWND_32(hwnd);
+    HMENU menu = GetMenu(hwnd32);
+    MENUITEMINFOA mii = {0};
+    mii.cbSize = sizeof(MENUITEMINFOA);
+    mii.fMask = MIIM_TYPE | MIIM_SUBMENU;
+    if (GetMenuItemInfoA(menu, 0, TRUE, &mii) && (mii.fType & MFT_BITMAP) && mii.hSubMenu)
+    {
+        mii.fMask = MIIM_BITMAP;
+        if (GetMenuItemInfoA(menu, 1, TRUE, &mii))
+        {
+            // if the second item is a bitmap, it's probably a buttonbar
+            if (!mii.hbmpItem)
+            {
+                mii.hbmpItem = HBMMENU_SYSTEM;
+                SetMenuItemInfoA(menu, 0, TRUE, &mii);
+            }
+        }
+    }
+    DrawMenuBar(hwnd32);
 }
 
 


### PR DESCRIPTION
…e the menu is a bar and not a popup and check that it's the only bitmap so the menu isn't a button bar   This should prevent the most if not all false positives.

In Excel and many other fake mdi programs (but not all) the system menu icon displayed is the child window icon not the default system menu icon.  This also works in ntvdm so there must be special casing in User for this.