### PR TITLE
force allocation of tlsexpansionslots to prevent crash in tebtlssetvalue

### DIFF
--- a/krnl386/kernel.c
+++ b/krnl386/kernel.c
@@ -51,6 +51,7 @@ static void thread_attach(void)
 	setWOW32Reserved((void *)MAKESEGPTR(kernel_get_thread_data()->stack_sel,
                                                         0x10000 - sizeof(STACK16FRAME) ));
 	memset((char *)GlobalLock16(hstack) + 0x10000 - sizeof(STACK16FRAME), 0, sizeof(STACK16FRAME));
+	TlsSetValue(64, 0); // force allocation of TlsExpansionSlots
 }
 
 


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/552