### PR TITLE
ignore cbsize when format tag is pcm

### DIFF
--- a/mmsystem/mmsystem.c
+++ b/mmsystem/mmsystem.c
@@ -1304,9 +1304,10 @@ UINT16 WINAPI waveOutOpen16(HWAVEOUT16* lphWaveOut, UINT16 uDeviceID,
     UINT		        ret;
     struct mmsystdrv_thunk*     thunk;
     WAVEFORMATEX             *wavefmt;
-    wavefmt = (WAVEFORMATEX *)HeapAlloc(GetProcessHeap(), 0, sizeof(WAVEFORMATEX) + lpFormat->cbSize);
+    WORD                        size = lpFormat->wFormatTag == WAVE_FORMAT_PCM ? 0 : lpFormat->cbSize;
+    wavefmt = (WAVEFORMATEX *)HeapAlloc(GetProcessHeap(), 0, sizeof(WAVEFORMATEX) + size);
 
-    memcpy(wavefmt, lpFormat, sizeof(WAVEFORMATEX) + lpFormat->cbSize);
+    memcpy(wavefmt, lpFormat, sizeof(WAVEFORMATEX) + size);
 
 
     if (!(thunk = MMSYSTDRV_AddThunk(dwCallback, dwFlags, MMSYSTDRV_WAVEOUT)))


### PR DESCRIPTION
fixes crash, https://github.com/otya128/winevdm/issues/557#issuecomment-562855434, where cbsize is uninitialized.  docs say this explicitly https://docs.microsoft.com/en-us/previous-versions/dd757713(v=vs.85) "WAVE_FORMAT_PCM formats (and only WAVE_FORMAT_PCM formats), this member is ignored"