### PR TITLE
add 640x480 compat mode

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -1972,6 +1972,18 @@ INT16 WINAPI GetDeviceCaps16( HDC16 hdc, INT16 cap )
         }
     }
     else if ((cap == NUMCOLORS) && (ret == -1)) ret = 2048;
+    if (krnl386_get_compat_mode("640X480") && (GetDeviceCaps(hdc32, TECHNOLOGY) == DT_RASDISPLAY))
+    {
+        switch (cap)
+        {
+            case HORZRES:
+                ret = 640;
+                break;
+            case VERTRES:
+                ret = 480;
+                break;
+        }
+    }
     return ret;
 }
 

--- a/user/user.c
+++ b/user/user.c
@@ -1417,6 +1417,17 @@ INT16 WINAPI GetSystemMetrics16( INT16 index )
             }
         }
     }
+    if (krnl386_get_compat_mode("640X480"))
+    {
+        switch (index)
+        {
+            case SM_CXSCREEN:
+                return 640;
+            case SM_CYSCREEN:
+                return 480;
+        }
+    }
+        
     return GetSystemMetrics( index );
 }
 


### PR DESCRIPTION
Permits some programs that fill the screen but only use a ~640x480 section for the actual game to work with scalers (https://github.com/otya128/winevdm/issues/561).