### PR TITLE
zero dmdriverextra because some programs don't like large values there

### DIFF
--- a/commdlg/printdlg.c
+++ b/commdlg/printdlg.c
@@ -194,6 +194,9 @@ BOOL16 WINAPI PrintDlg16( SEGPTR pd )
         lppd->nMinPage    = pd32.nMinPage;
         lppd->nMaxPage    = pd32.nMaxPage;
         lppd->nCopies     = pd32.nCopies;
+        DEVMODEA *dm = GlobalLock16(lppd->hDevMode);
+        dm->dmDriverExtra = 0;
+        GlobalUnlock16(lppd->hDevMode);
     }
     GlobalFree( pd32.hDevNames );
     GlobalFree( pd32.hDevMode );


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/565 (maybe)

Doesn't seem to effect the few programs i tried that use PrintDlg.