### PR TITLE
Oxford superlex changes the menu in it's WM_CREATE handler.  Since th…

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -3133,7 +3133,8 @@ HWND16 WINAPI CreateWindowEx16( DWORD exStyle, LPCSTR className,
     HWND16 hWnd16 = HWND_16(hwnd);
 	InitWndProc16(hwnd, hWnd16);
     SetWindowHInst16(hWnd16, instance);
-    SetWindowHMenu16(hWnd16, menu);
+    if (!GetWindowHMenu16(hWnd16))
+        SetWindowHMenu16(hWnd16, menu);
 	return hWnd16;
 }
 void InitWndProc16(HWND hWnd, HWND16 hWnd16)


### PR DESCRIPTION
…e window data is cleared when reallocated we can just check if the hmenu hint is already set in createwindowex16.

Fixes https://github.com/otya128/winevdm/issues/568