### PR TITLE
support x87 exceptions and the win87em handler

### DIFF
--- a/krnl386/krnl386.def
+++ b/krnl386/krnl386.def
@@ -218,6 +218,8 @@ EXPORTS
   DOSVM_outport
   DOSVM_setportcb
   DOSVM_SetBuiltinVector
+  DOSVM_GetPMHandler16
+  DOSVM_SetPMHandler16
   krnl386_get_search_path
   krnl386_search_executable_file
   get_aflags

--- a/krnl386/krnl386.exe16.spec
+++ b/krnl386/krnl386.exe16.spec
@@ -772,6 +772,8 @@
 @ cdecl -arch=win32 DOSVM_outport(long long long)
 @ cdecl -arch=win32 DOSVM_setportcb(ptr ptr long ptr ptr)
 @ cdecl -arch=win32 DOSVM_SetBuiltinVector(long ptr)
+@ cdecl -arch=win32 DOSVM_GetPMHandler16(long long)
+@ cdecl -arch=win32 DOSVM_SetPMHandler16(long long)
 @ cdecl -arch=win32 krnl386_get_search_path()
 @ cdecl -arch=win32 krnl386_search_executable_file(str ptr long long)
 @ stdcall -arch=win32 DibMapGlobalMemory(long ptr long)

--- a/vm86/mame/emu/cpu/i386/i386ops.h
+++ b/vm86/mame/emu/cpu/i386/i386ops.h
@@ -189,6 +189,7 @@ static const X86_OPCODE x86_opcode_table[] =
 	{ 0x99,     OP_I386,                    I386OP(cwd),                    I386OP(cdq),                false},
 	{ 0x9A,     OP_I386,                    I386OP(call_abs16),             I386OP(call_abs32),         false},
 	{ 0x9B,     OP_I386,                    I386OP(wait),                   I386OP(wait),               false},
+	{ 0x9B,     OP_I486,                    I486OP(wait),                   I486OP(wait),               false},
 	{ 0x9C,     OP_I386,                    I386OP(pushf),                  I386OP(pushfd),             false},
 	{ 0x9D,     OP_I386,                    I386OP(popf),                   I386OP(popfd),              false},
 	{ 0x9E,     OP_I386,                    I386OP(sahf),                   I386OP(sahf),               false},

--- a/vm86/mame/emu/cpu/i386/i386priv.h
+++ b/vm86/mame/emu/cpu/i386/i386priv.h
@@ -19,6 +19,7 @@
 #define SSEOP(XX)       sse_##XX
 
 extern int i386_dasm_one(char *buffer, UINT32 pc, const UINT8 *oprom, int mode);
+extern int x87_mf_fault();
 
 enum SREGS { ES, CS, SS, DS, FS, GS };
 
@@ -417,7 +418,9 @@ union XMM_REG {
 	UINT16 m_x87_cw;
 	UINT16 m_x87_sw;
 	UINT16 m_x87_tw;
+	UINT16 m_x87_ds;
 	UINT64 m_x87_data_ptr;
+	UINT16 m_x87_cs;
 	UINT64 m_x87_inst_ptr;
 	UINT16 m_x87_opcode;
 

--- a/vm86/mame/emu/cpu/i386/i486ops.c
+++ b/vm86/mame/emu/cpu/i386/i486ops.c
@@ -518,3 +518,8 @@ static void I486OP(mov_cr_r32)()        // Opcode 0x0f 22
 	}
 	m_cr[cr] = data;
 }
+
+void I486OP(wait)()
+{
+	x87_mf_fault();
+}

--- a/vm86/msdos.cpp
+++ b/vm86/msdos.cpp
@@ -1509,6 +1509,8 @@ extern "C"
                         context.Eip = return_ip;
                         context.SegCs = return_cs;
                         context.EFlags = flags;
+                        if ((num == FAULT_MF) && (m_x87_sw & 0x80))
+                            num = 2;  // redirect fpu error to nmi
                         dynamic__wine_call_int_handler(&context, num);
                         mem = memory_base;
                         load_context(&context);

--- a/win87em/win87em.dll16.spec
+++ b/win87em/win87em.dll16.spec
@@ -6,3 +6,4 @@
 4 pascal -ret16 __Win87EmRestore(ptr word) __WinEm87Restore
 5 pascal -ret16 __Win87EmSave(ptr word) __WinEm87Save
 
+100 pascal -register fpe_return() fpe_return


### PR DESCRIPTION
There's a good probability of regressions here because programs that expect fpu exceptions seem to also expect specific behavior from win87em.  Some of it can't even be implemented on haxm with haswell and newer cpus because of the fds fcs deprecation (if they had stored the full linear address like in real mode it wouldn't have been a problem, thanks intel).  It's good enough to fix https://github.com/otya128/winevdm/issues/563 though.