### PR TITLE
make sure wheel scroll message are sent to a visible sb

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -2869,7 +2869,7 @@ static void check_scrollable(enum_scrollbar_data *d, HWND hwnd)
     {
         if (GetScrollInfo(hwnd, SB_CTL, &si))
         {
-            if (GetWindowLongW(hwnd, GWL_STYLE) & SBS_VERT)
+            if ((GetWindowLongW(hwnd, GWL_STYLE) & (SBS_VERT | WS_VISIBLE)) == (SBS_VERT | WS_VISIBLE))
             {
                 d->found = TRUE;
                 if ((d->down && si.nMax > si.nPos) || (!d->down && si.nMin < si.nPos))


### PR DESCRIPTION
vb4 code windows have 2 vert scroll bars, one is hidden, make sure the message references the visible one else it crashes