### PR TITLE
more typelib fixes

### DIFF
--- a/ole2disp/ole2disp.dll16.spec
+++ b/ole2disp/ole2disp.dll16.spec
@@ -85,7 +85,7 @@
 85 stub VARCYFROMR4
 86 stub VARCYFROMR8
 87 stub VARCYFROMDATE
-88 stub VARCYFROMSTR
+88 pascal VarCyFromStr(str long long ptr) VarCyFromStr16
 89 stub VARCYFROMDISP
 90 stub VARCYFROMBOOL
 91 pascal VarBstrFromI2(s_word long long ptr) VarBstrFromI216


### PR DESCRIPTION
With this most of the vb4 samples work, the ones that don't seem to all have a problem with const ole control enum members.