### PR TITLE
set cpu model to 486 so the fpu is reset properly

### DIFF
--- a/vm86/CMakeLists.txt
+++ b/vm86/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(vm86 SHARED msdos.cpp vm86.def)
 include_directories(../wine)
-add_definitions(-D__i386__ -DHAS_I386 -DSUPPORT_FPU -DNtCurrentTeb=NtCurrentTeb__ -DDECLSPEC_HIDDEN= -Uinline -DPSAPI_VERSION=1)
+add_definitions(-D__i386__ -DHAS_I486 -DSUPPORT_FPU -DNtCurrentTeb=NtCurrentTeb__ -DDECLSPEC_HIDDEN= -Uinline -DPSAPI_VERSION=1)
 if (NOT(MSVC))
     string(APPEND CMAKE_CXX_FLAGS " -fpermissive -Wl,--enable-stdcall-fixup ")
 endif()

--- a/vm86/vm86.vcxproj
+++ b/vm86/vm86.vcxproj
@@ -54,7 +54,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>USE_COMPILER_EXCEPTIONS;__i386__;WIN32;_DEBUG;_WINDOWS;_USRDLL;VM86_EXPORTS;_CONSOLE;HAS_I386;SUPPORT_FPU;NtCurrentTeb=NtCurrentTeb__;DECLSPEC_HIDDEN=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_COMPILER_EXCEPTIONS;__i386__;WIN32;_DEBUG;_WINDOWS;_USRDLL;VM86_EXPORTS;_CONSOLE;HAS_I486;SUPPORT_FPU;NtCurrentTeb=NtCurrentTeb__;DECLSPEC_HIDDEN=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../wine</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -74,7 +74,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>USE_COMPILER_EXCEPTIONS;__i386__;WIN32;NDEBUG;_WINDOWS;_USRDLL;VM86_EXPORTS;HAS_I386;SUPPORT_FPU;NtCurrentTeb=NtCurrentTeb__;DECLSPEC_HIDDEN=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_COMPILER_EXCEPTIONS;__i386__;WIN32;NDEBUG;_WINDOWS;_USRDLL;VM86_EXPORTS;HAS_I486;SUPPORT_FPU;NtCurrentTeb=NtCurrentTeb__;DECLSPEC_HIDDEN=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../wine</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>


### PR DESCRIPTION
fixes crash in excel 2 due to all fpu exceptions being unmasked