### PR TITLE
call int 3 instead of NtRaiseException as the latter isn't recoverabl…

### DIFF
--- a/haxmvm/haxmvm.c
+++ b/haxmvm/haxmvm.c
@@ -824,7 +824,7 @@ void relay(LPVOID relay_func, BOOL reg, struct vcpu_state_t *state, DWORD ret_ad
     {
         context.Esp = osp + (SIZE_T)stack - (SIZE_T)stack1 - 4;
         off = ooo - context.Esp;
-        context.Ebp = bp;
+        context.Ebp = (context.Ebp & ~0xffff) | bp;
         context.Eip = ip19;
         context.SegCs = cs16;
     }

--- a/krnl386/kernel.c
+++ b/krnl386/kernel.c
@@ -497,6 +497,7 @@ BOOL16 WINAPI GetVersionEx16(OSVERSIONINFO16 *v)
  */
 void WINAPI DebugBreak16( CONTEXT *context )
 {
+/*
     EXCEPTION_RECORD rec;
 
     rec.ExceptionCode    = EXCEPTION_BREAKPOINT;
@@ -505,6 +506,8 @@ void WINAPI DebugBreak16( CONTEXT *context )
     rec.ExceptionAddress = (LPVOID)context->Eip;
     rec.NumberParameters = 0;
     NtRaiseException( &rec, context, TRUE );
+*/
+    __wine_call_int_handler(context, 3);
 }
 
 /***********************************************************************

--- a/vm86/msdos.cpp
+++ b/vm86/msdos.cpp
@@ -1619,7 +1619,7 @@ extern "C"
                         {
                             context.Esp = osp + (SIZE_T)stack - (SIZE_T)stack1 - 4;
                             off = ooo - context.Esp;
-                            context.Ebp = bp;
+                            context.Ebp = (context.Ebp & ~0xffff) | bp;
                             context.Eip = ip19;
                             context.SegCs = cs16;
                         }
@@ -1887,6 +1887,7 @@ extern "C"
 #endif
                     fprintf(stderr, "\t%s\n", buffer);
 #if !defined(TRACE_REGS)
+                        DWORD stkptr = m_sreg[SS].base + (m_sreg[SS].d ? REG32(ESP) : REG16(SP));
                         if (SREG(FS) || SREG(GS))
                         {
                             fprintf(stderr,
@@ -1898,7 +1899,7 @@ IP:%04X,stack:%08X,\
 EFLAGS:%08X\
 \n",
 REG32(EAX), REG32(ECX), REG32(EDX), REG32(EBX), REG32(ESP), REG32(EBP), REG32(ESI), REG32(EDI),
-SREG(ES), SREG(CS), SREG(SS), SREG(DS), SREG(FS), SREG(GS), m_eip, read_dword(SREG_BASE(SS) + REG32(ESP)), m_eflags);
+SREG(ES), SREG(CS), SREG(SS), SREG(DS), SREG(FS), SREG(GS), m_eip, read_dword(stkptr), m_eflags);
                         }
                         else
                         {
@@ -1911,7 +1912,7 @@ IP:%04X,stack:%08X,\
 EFLAGS:%08X\
 \n",
 REG32(EAX), REG32(ECX), REG32(EDX), REG32(EBX), REG32(ESP), REG32(EBP), REG32(ESI), REG32(EDI),
-SREG(ES), SREG(CS), SREG(SS), SREG(DS), m_eip, read_dword(SREG_BASE(SS) + REG32(ESP)), m_eflags);
+SREG(ES), SREG(CS), SREG(SS), SREG(DS), m_eip, read_dword(stkptr), m_eflags);
                         }
 #endif
                 }

--- a/whpxvm/whpxvm.c
+++ b/whpxvm/whpxvm.c
@@ -643,7 +643,7 @@ void relay(LPVOID relay_func, BOOL reg, struct whpx_vcpu_state *state, DWORD ret
     {
         context.Esp = osp + (SIZE_T)stack - (SIZE_T)stack1 - 4;
         off = ooo - context.Esp;
-        context.Ebp = bp;
+        context.Ebp = (context.Ebp & ~0xffff) | bp;
         context.Eip = ip19;
         context.SegCs = cs16;
     }


### PR DESCRIPTION
…e and don't lose the high word of ebp

fixes part of https://github.com/otya128/winevdm/issues/652