### PR TITLE
translate hwnd form user32 setscrollinfo

### DIFF
--- a/krnl386/thunk.c
+++ b/krnl386/thunk.c
@@ -2450,6 +2450,8 @@ DWORD WINAPI LoadLibraryEx32W16( LPCSTR lpszLibFile, DWORD hFile, DWORD dwFlags 
 // workaround for dsinterface.dll
 static DWORD DSI_InitializeDirectSound = 0;
 static DWORD DSI_InitializeSound = 0;
+// workaround for user32.dll
+static DWORD USER32_SetScrollInfo = 0;
 
 /***********************************************************************
  *           GetProcAddress32W     (KERNEL.515)
@@ -2461,6 +2463,8 @@ DWORD WINAPI GetProcAddress32W16( DWORD hModule, LPCSTR lpszProc )
         DSI_InitializeDirectSound = ret;
     else if(!strcmp(lpszProc, "InitializeSound"))
         DSI_InitializeSound = ret;
+    else if(!strcmp(lpszProc, "SetScrollInfo"))
+        USER32_SetScrollInfo = ret;
     return ret;
 }
 
@@ -2531,7 +2535,7 @@ DWORD WINAPIV CallProc32W16( DWORD nrofargs, DWORD argconvmask, FARPROC proc32, 
     /* POP nrofargs DWORD arguments and 3 DWORD parameters */
     stack16_pop( (3 + nrofargs) * sizeof(DWORD) );
 
-    if ((proc32 == DSI_InitializeDirectSound) || (proc32 == DSI_InitializeSound))
+    if ((proc32 == DSI_InitializeDirectSound) || (proc32 == DSI_InitializeSound) || (proc32 == USER32_SetScrollInfo))
         args[0] = HWND_32(args[0]);
     return WOW_CallProc32W16( proc32, nrofargs, args );
 }


### PR DESCRIPTION
fixes notabene scroll bars.  There could be quite a few of these workaround but notabene at least appears to use wowhandle32 for dc handles so that makes things a bit simpler.