### PR TITLE
ntvdm fails GetPrivateProfileString if filename is null and the byref…

### DIFF
--- a/krnl386/file.c
+++ b/krnl386/file.c
@@ -1376,6 +1376,11 @@ INT16 WINAPI GetPrivateProfileString16( LPCSTR section, LPCSTR entry,
     char filenamebuf[MAX_PATH];
     BOOL overwrite_section = FALSE;
     TRACE("%s %s %s\n", filename, section, entry);
+    if (!section || !filename)
+    {
+        if (buffer && len) buffer[0] = 0;
+        return 0;
+    }
     LPCSTR filename_file = PathFindFileNameA(filename);
     if (entry)
     {
@@ -1432,11 +1437,6 @@ INT16 WINAPI GetPrivateProfileString16( LPCSTR section, LPCSTR entry,
     TRACE("(%s, %s, %s, %p, %u, %s)\n", debugstr_a(section), debugstr_a(entry),
           debugstr_a(def_val), buffer, len, debugstr_a(filename));
 
-    if (!section)
-    {
-        if (buffer && len) buffer[0] = 0;
-        return 0;
-    }
     /* len = 0 means unlimited buffer length (windows bug?) */
     if (!entry && len == 0)
     {

--- a/ole2disp/wine_typelib.c
+++ b/ole2disp/wine_typelib.c
@@ -7719,7 +7719,7 @@ static HRESULT CDECL ITypeInfo_fnInvoke16(
                         prgpvarg[i] = src_arg;
                     }
 
-                    if((tdesc->vt == VT_USERDEFINED || (tdesc->vt == VT_PTR && ((TYPEDESC16*)MapSL(tdesc->u.lptdesc))->vt == VT_USERDEFINED))
+                    if((tdesc->vt == VT_USERDEFINED || (tdesc->vt == VT_PTR && tdesc->u.lptdesc->vt == VT_USERDEFINED))
                        && (V_VT(prgpvarg[i]) == VT_DISPATCH || V_VT(prgpvarg[i]) == VT_UNKNOWN)
                        && V_UNKNOWN(prgpvarg[i])) {
                         SEGPTR userdefined_iface;
@@ -7821,7 +7821,7 @@ static HRESULT CDECL ITypeInfo_fnInvoke16(
                     {
                         if ((rgvt[i] & VT_BYREF) && !(V_VT(arg) & VT_BYREF))
                         {
-                            hres = VariantChangeType16(arg, &rgvarg[i], 0, V_VT(arg));
+                            hres = VariantChangeType(arg, &rgvarg[i], 0, V_VT(arg));
 
                             if (FAILED(hres))
                             {


### PR DESCRIPTION
… params are already converted to pointers in itypeinfo_fninvoke16

fixes new file and closing in https://github.com/otya128/winevdm/issues/592