### PR TITLE
Printer issues

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -27,6 +27,7 @@
 #include "wingdi.h"
 #include "winuser.h"
 #include "wownt32.h"
+#include "winspool.h"
 #include "wine/wingdi16.h"
 #include "wine/list.h"
 #if 0
@@ -1618,6 +1619,14 @@ HDC16 WINAPI CreateDC16( LPCSTR driver, LPCSTR device, LPCSTR output,
     const DEVMODEA *initData = (const DEVMODEA*)MapSL(segInitData);
     HDC16 dc;
     HINSTANCE16 drv;
+    char tmp[256];
+    if (device && !strcmp(device, "DefaultPrinter"))
+    {
+        int len = 256;
+        if (GetDefaultPrinterA(tmp, &len))
+            device = tmp;
+    }
+
 #if 0
     if (!lstrcmpiA( driver, "dib" ) || !lstrcmpiA( driver, "dirdib" ))
     {
@@ -2754,6 +2763,13 @@ BOOL16 WINAPI UnrealizeObject16( HGDIOBJ16 obj )
 HDC16 WINAPI CreateIC16( LPCSTR driver, LPCSTR device, LPCSTR output,
                          const DEVMODEA* initData )
 {
+    char tmp[256];
+    if (device && !strcmp(device, "DefaultPrinter"))
+    {
+        int len = 256;
+        if (GetDefaultPrinterA(tmp, &len))
+            device = tmp;
+    }
     return HDC_16( CreateICA( driver, device, output, initData ) );
 }
 

--- a/krnl386/file.c
+++ b/krnl386/file.c
@@ -408,8 +408,26 @@ UINT16 WINAPI GetProfileInt16( LPCSTR section, LPCSTR entry, INT16 def_val )
 INT16 WINAPI GetProfileString16( LPCSTR section, LPCSTR entry, LPCSTR def_val,
                                  LPSTR buffer, UINT16 len )
 {
-    return GetPrivateProfileString16( section, entry, def_val,
+    char tmp[256];
+    if (section && entry && !stricmp(section, "devices") && !stricmp(entry, "DefaultPrinter"))
+    {
+        int len = 256;
+        if (GetDefaultPrinterA(tmp, &len))
+            entry = tmp;
+    }
+    INT16 ret = GetPrivateProfileString16( section, entry, def_val,
                                       buffer, len, "win.ini" );
+    if (ret && section && entry && !stricmp(section, "windows") && !stricmp(entry, "device"))
+    {
+        char *comma = strchr(buffer, ',');
+        if (comma && ((comma - buffer) > 32))
+        {
+            strcpy(buffer, "DefaultPrinter");
+            strcpy(buffer + 14, comma);
+        }
+        ret = strlen(buffer);
+    }
+    return ret;
 }
 
 /***********************************************************************

--- a/krnl386/krnl386.vcxproj
+++ b/krnl386/krnl386.vcxproj
@@ -67,7 +67,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(OutDir)winecrt0.lib;lz32.lib;$(OutDir)libwine.lib;ntdll.lib;ddraw.lib;dsound.lib;kernel32.lib;advapi32.lib;user32.lib;shell32.lib;gdi32.lib</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)winecrt0.lib;lz32.lib;$(OutDir)libwine.lib;ntdll.lib;ddraw.lib;dsound.lib;kernel32.lib;advapi32.lib;user32.lib;shell32.lib;gdi32.lib;winspool.lib</AdditionalDependencies>
       <ModuleDefinitionFile>krnl386.def</ModuleDefinitionFile>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
@@ -87,7 +87,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>$(OutDir)winecrt0.lib;lz32.lib;$(OutDir)libwine.lib;ntdll.lib;ddraw.lib;dsound.lib;kernel32.lib;advapi32.lib;user32.lib;shell32.lib;gdi32.lib</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)winecrt0.lib;lz32.lib;$(OutDir)libwine.lib;ntdll.lib;ddraw.lib;dsound.lib;kernel32.lib;advapi32.lib;user32.lib;shell32.lib;gdi32.lib;winspool.lib</AdditionalDependencies>
       <ForceFileOutput>
       </ForceFileOutput>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>

--- a/winspool/winspool.c
+++ b/winspool/winspool.c
@@ -101,6 +101,13 @@ void DEVMODE32To16(LPDEVMODE16 dst, const LPDEVMODEA src, LONG extra)
 }
 int WINAPI ExtDeviceMode16(HWND16 hwnd16, HANDLE16 hDriver16, LPDEVMODE16 pDevModeOutput, LPSTR pDeviceName, LPSTR pPort, LPDEVMODE16 pDevModeInput, LPSTR pProfile, WORD fMode)
 {
+    char tmp[256];
+    if (pDeviceName && !strcmp(pDeviceName, "DefaultPrinter"))
+    {
+        int len = 256;
+        if (GetDefaultPrinterA(tmp, &len))
+            pDeviceName = tmp;
+    }
     LONG size = ExtDeviceMode(HWND_32(hwnd16), (HANDLE)hDriver16, NULL, pDeviceName, pPort, NULL, pProfile, 0);
     if (!fMode)
         return size;
@@ -123,7 +130,7 @@ DWORD WINAPI DeviceCapabilities16(LPCSTR pDevice, LPCSTR pPort, WORD fwCapabilit
     char devmode32[65536] = { 0 };
     if (pDevMode)
         DEVMODE16To32(pDevMode, (LPDEVMODEA)&devmode32[0], 0);
-    DWORD result = 0;
+    WORD result = 0;
     switch (fwCapability)
     {
     case DC_FIELDS:

--- a/winspool/winspool.c
+++ b/winspool/winspool.c
@@ -130,7 +130,7 @@ DWORD WINAPI DeviceCapabilities16(LPCSTR pDevice, LPCSTR pPort, WORD fwCapabilit
     char devmode32[65536] = { 0 };
     if (pDevMode)
         DEVMODE16To32(pDevMode, (LPDEVMODEA)&devmode32[0], 0);
-    WORD result = 0;
+    DWORD result = 0;
     switch (fwCapability)
     {
     case DC_FIELDS:


### PR DESCRIPTION
try to work around the printer name length issue by using an alias for the default printer, ntvdm does something similar but it just shows "printer name too long" and doesn't try to make the printer actually work.  also convert devmode in printdlg which fixes clarisworks startup