### PR TITLE
don't release the dc unless the hdc and hwnd match

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -1162,12 +1162,12 @@ HDC16 WINAPI GetWindowDC16( HWND16 hwnd )
  */
 INT16 WINAPI ReleaseDC16( HWND16 hwnd, HDC16 hdc )
 {
+    if (!hwnd)
+        hwnd = HWND_16(GetDesktopWindow());
+    if (WindowFromDC(HDC_32(hdc)) != HWND_32(hwnd))
+        return 0;
     if (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a)
     {
-        if (!hwnd)
-            hwnd = HWND_16(GetDesktopWindow());
-        if (WindowFromDC(HDC_32(hdc)) != HWND_32(hwnd))
-            return 0;
         if (dcc.dcs[dcc.next])
         {
             HDC16 oldhdc = dcc.dcs[dcc.next];


### PR DESCRIPTION
In https://github.com/otya128/winevdm/issues/661#issuecomment-627087559 it looks like releasedc is called on the printer dc.  Ntvdm and win31 appear to work this way but it's hard to test fully.
fixes https://github.com/otya128/winevdm/issues/661 and fixes https://github.com/otya128/winevdm/issues/660