### PR TITLE
try to make sure devmode passed to createdc is okay

### DIFF
--- a/commdlg/printdlg.c
+++ b/commdlg/printdlg.c
@@ -77,7 +77,7 @@ void DEVMODE16To32(CONST DEVMODE16 *src, LPDEVMODEA dst)
     dst->dmDriverVersion = src->dmDriverVersion;
     dst->dmSize = sizeof(DEVMODE16);
     dst->dmDriverExtra = 0;
-    dst->dmFields = src->dmFields;
+    dst->dmFields = src->dmFields & 0x7fbf;
     dst->dmOrientation = src->dmOrientation;
     dst->dmPaperSize = src->dmPaperSize;
     dst->dmPaperLength = src->dmPaperLength;
@@ -99,7 +99,7 @@ void DEVMODE32To16(LPDEVMODE16 dst, const LPDEVMODEA src)
     dst->dmDriverVersion = src->dmDriverVersion;
     dst->dmSize = sizeof(DEVMODE16);
     dst->dmDriverExtra = 0;
-    dst->dmFields = src->dmFields;
+    dst->dmFields = src->dmFields & 0x7fbf;
     dst->dmOrientation = src->dmOrientation;
     dst->dmPaperSize = src->dmPaperSize;
     dst->dmPaperLength = src->dmPaperLength;

--- a/gdi/CMakeLists.txt
+++ b/gdi/CMakeLists.txt
@@ -3,5 +3,5 @@ add_library(gdi SHARED ${SOURCE} ${CMAKE_CURRENT_BINARY_DIR}/gdi.def gdi.exe16.o
 include_directories(../wine)
 add_definitions(-D_X86_ -D__WINESRC__ -D__i386__ -DHAVE_STRNCASECMP -DHAVE__STRNICMP -D_WINTERNL_ -DNtCurrentTeb=NtCurrentTeb__ -DDECLSPEC_HIDDEN= -Dstrncasecmp=_strnicmp)
 spec_build(gdi.exe16 GDI ARG --heap 65520)
-target_link_libraries(gdi libwine winecrt0 krnl386 user)
+target_link_libraries(gdi libwine winecrt0 krnl386 user winspool)
 set_target_properties(gdi PROPERTIES SUFFIX ".exe16")

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -1693,7 +1693,7 @@ HDC16 WINAPI CreateDC16( LPCSTR driver, LPCSTR device, LPCSTR output,
         else
         {
             memcpy(&dma, initData, initData->dmSize);
-            dma.dmSize = 0x9c;
+            dma.dmSize = sizeof(DEVMODEA);
             dma.dmDriverExtra = 0;
             return HDC_16( CreateDCA( driver, device, output, &dma ) );
         }

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -1685,6 +1685,20 @@ HDC16 WINAPI CreateDC16( LPCSTR driver, LPCSTR device, LPCSTR output,
         return HDC_16(memdc);
     }
 #endif
+    if (initData && (!driver || !stricmp(driver, "winspool")))
+    {
+        DEVMODEA dma = {0};
+        if (!IsValidDevmodeA(initData, initData->dmSize + initData->dmDriverExtra))
+            initData = NULL;
+        else
+        {
+            memcpy(&dma, initData, initData->dmSize);
+            dma.dmSize = 0x9c;
+            dma.dmDriverExtra = 0;
+            return HDC_16( CreateDCA( driver, device, output, &dma ) );
+        }
+    }
+    
     dc = HDC_16( CreateDCA( driver, device, output, initData ) );
 
     if (dc)

--- a/gdi/gdi.vcxproj
+++ b/gdi/gdi.vcxproj
@@ -62,7 +62,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(OutDir)winecrt0.lib;$(OutDir)krnl386.lib;$(OutDir)user.lib;$(OutDir)libwine.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;advapi32.lib</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)winecrt0.lib;$(OutDir)krnl386.lib;$(OutDir)user.lib;$(OutDir)libwine.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;advapi32.lib;winspool.lib</AdditionalDependencies>
       <ModuleDefinitionFile>gdi.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -84,7 +84,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>gdi.def</ModuleDefinitionFile>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
-      <AdditionalDependencies>$(OutDir)winecrt0.lib;$(OutDir)krnl386.lib;$(OutDir)user.lib;$(OutDir)libwine.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;advapi32.lib</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)winecrt0.lib;$(OutDir)krnl386.lib;$(OutDir)user.lib;$(OutDir)libwine.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;advapi32.lib;winspool.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
fixes fault in print artist 1500

Testing with xp and w10 64bit appears to show that the 32bit version doesn't care about the devmode contents as long as it's size and fields are valid.  64bit wants the size to be 0x9c no matter what fields is.