### PR TITLE
windows doesn't check for null pointers in lstrcat but if a pointer h…

### DIFF
--- a/krnl386/kernel.c
+++ b/krnl386/kernel.c
@@ -415,7 +415,7 @@ SEGPTR WINAPI lstrcpy16( SEGPTR dst, LPCSTR src )
  */
 SEGPTR WINAPI lstrcat16( SEGPTR dst, LPCSTR src )
 {
-    /* Windows does not check for NULL pointers here, so we don't either */
+    if (!src || !dst) return 0;
     strcat( MapSL(dst), src );
     return dst;
 }


### PR DESCRIPTION
…appens to be null, it's handled silently (todo: or invalid at all)

Fixes darkseed ii full install