### PR TITLE
make hidden repaint much less aggressive

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -1266,6 +1266,12 @@ static ATOM topic32_16(ATOM atom)
     return atom;
 }
 
+static BOOL CALLBACK child_paint(HWND hwnd, LPARAM lparam)
+{
+    if (IsWindowVisible(hwnd) && !GetUpdateRect(hwnd, NULL, FALSE))
+        RedrawWindow(hwnd, NULL, NULL, RDW_INTERNALPAINT);
+}
+
 /**********************************************************************
  *	     WINPROC_CallProc16To32A
  */
@@ -2154,9 +2160,9 @@ LRESULT WINPROC_CallProc32ATo16( winproc_callback16_t callback, HWND hwnd, UINT 
         ret = callback( HWND_16(hwnd), msg, wParam, HTASK_16( lParam ), result, arg );
         break;
     case WM_PAINT:
-        // force a paint for win30 windows, KB Q80898
-        if ((GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a) && !(GetWindowLongA(hwnd, GWL_STYLE) & WS_CHILD))
-            RedrawWindow(hwnd, NULL, NULL, RDW_INTERNALPAINT | RDW_ALLCHILDREN);
+        // force a paint for hidden win30 windows, KB Q80898
+        if ((GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a) &&  !(GetWindowLongA(hwnd, GWL_STYLE) & WS_CHILD))
+            EnumChildWindows(hwnd, child_paint, NULL);
         if (IsIconic( hwnd ) && GetClassLongPtrW( hwnd, GCLP_HICON ))
             ret = callback( HWND_16(hwnd), WM_PAINTICON, 1, lParam, result, arg );
         else


### PR DESCRIPTION
In https://github.com/otya128/winevdm/pull/375 i said it might to too aggressive and it was because World Empire III broke.  This turns it down to only force a repaint for child windows which have ws_visible style but no update rect which hopefully should be exactly the difference between win30 and win31.