### PR TITLE
fix sb_thumb* edit control scroll messages

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -3846,6 +3846,8 @@ static LRESULT edit_proc_CallProc16To32A(winproc_callback_t callback, HWND hwnd,
         return callback(hwnd, msg, wParam, lParam, result, arg);/* no unlock on destroy */
     case WM_HSCROLL:
     case WM_VSCROLL:
+        if (LOWORD(wParam) == SB_THUMBTRACK || LOWORD(wParam) == SB_THUMBPOSITION)
+            return callback(hwnd, msg, MAKELONG(LOWORD(wParam), LOWORD(lParam)), NULL, result, arg);
         if (LOWORD(wParam) == EM_GETTHUMB16 || LOWORD(wParam) == EM_LINESCROLL16) wParam -= msg16_offset;
         return callback(hwnd, msg, wParam, lParam, result, arg);
     }


### PR DESCRIPTION
fixes notepad scroll bar, the bar still doesn't move correctly when dragged but this even happens with the windows nt 3.1 notepad on windows 10 so it's probably not fixable