### PR TITLE
yield in sndplaysound if snd_async is set to allow the play thread ti…

### DIFF
--- a/mmsystem/mmsystem.c
+++ b/mmsystem/mmsystem.c
@@ -328,6 +328,8 @@ BOOL16 WINAPI sndPlaySound16(LPCSTR lpszSoundName, UINT16 uFlags)
 
     ReleaseThunkLock(&lc);
     retv = sndPlaySoundA(lpszSoundName, uFlags);
+    if (uFlags & SND_ASYNC)
+        Sleep(1);
     RestoreThunkLock(lc);
 
     return retv;


### PR DESCRIPTION
…me to start

Fixes a race condition in powerhouse (https://github.com/otya128/winevdm/issues/704) where the sound effects don't play because they are stated with snd_async but the sndplaysound is afterward called with an silent wave and snd_nostop to detect the sound completion.  The later call doesn't use snd_async so starts first and prevents the earlier one from playing.