### PR TITLE
don't check the selector limit in hwrite

### DIFF
--- a/krnl386/file.c
+++ b/krnl386/file.c
@@ -912,9 +912,6 @@ LONG WINAPI WIN16_hread( HFILE16 hFile, SEGPTR buffer, LONG count )
 
     TRACE("%d %08x %d\n", hFile, (DWORD)buffer, count );
 
-    /* Some programs pass a count larger than the allocated buffer */
-    maxlen = GetSelectorLimit16( SELECTOROF(buffer) ) - OFFSETOF(buffer) + 1;
-    if (count > maxlen) count = maxlen;
     return _lread((HFILE)DosFileHandleToWin32Handle(hFile), MapSL(buffer), count );
 }
 


### PR DESCRIPTION
Testing with ntvdm shows it'll happily overrun selector limits.  Fixes loading in powerhouse (https://github.com/otya128/winevdm/issues/704#issuecomment-647030652).