### PR TITLE
openfile sets es to selector of the openfilestruct

### DIFF
--- a/krnl386/file.c
+++ b/krnl386/file.c
@@ -597,6 +597,12 @@ static HANDLE create_file_OF( LPCWSTR path, INT mode )
  *           OpenFile   (KERNEL.74)
  *           OpenFileEx (KERNEL.360)
  */
+HFILE16 WINAPI WIN16_OpenFile16( LPCSTR name, SEGPTR ofs, UINT16 mode )
+{
+    CURRENT_STACK16->es = SELECTOROF(ofs);
+    return OpenFile16(name, MapSL(ofs), mode);
+}
+
 HFILE16 WINAPI OpenFile16( LPCSTR name, OFSTRUCT *ofs, UINT16 mode )
 {
     HFILE hFileRet;

--- a/krnl386/int21.c
+++ b/krnl386/int21.c
@@ -4936,6 +4936,7 @@ void WINAPI DOSVM_Int21Handler( CONTEXT *context )
             else
             {
                 HFILE handle = (HFILE)DosFileHandleToWin32Handle(BX_reg(context));
+                if (!context->SegDs) ptr = MapSL(MAKELONG(context->Edx & 0xffff, DOSMEM_0000H));
                 LONG result = _hwrite( handle, ptr, CX_reg(context) );
                 if (result == HFILE_ERROR)
                     bSetDOSExtendedError = TRUE;

--- a/krnl386/krnl386.exe16.spec
+++ b/krnl386/krnl386.exe16.spec
@@ -74,7 +74,7 @@
 71  pascal -ret16 DeleteAtom(word) DeleteAtom16
 72  pascal -ret16 GetAtomName(word ptr word) GetAtomName16
 73  pascal -ret16 GetAtomHandle(word) GetAtomHandle16
-74  pascal -ret16 OpenFile(str ptr word) OpenFile16
+74  pascal -ret16 OpenFile(str long word) WIN16_OpenFile16
 75  stub OpenPathName
 76  stub DeletePathName
 # Reserved*: old Win 2.x functions now moved to USER (Win 3.0+)


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/298

Ntvdm writes dosmem to a file if ds is 0.  Selector 0 probably is the only one that needs handling like this because any other can't be loaded into ds without being valid.  Presumably read would work the same way but that would likely crash the vdm so shouldn't need handling.