### PR TITLE
fix sm_c?fullscreen for 640x480 mode

### DIFF
--- a/user/user.c
+++ b/user/user.c
@@ -1435,9 +1435,12 @@ INT16 WINAPI GetSystemMetrics16( INT16 index )
         switch (index)
         {
             case SM_CXSCREEN:
+            case SM_CXFULLSCREEN:
                 return 640;
             case SM_CYSCREEN:
                 return 480;
+            case SM_CYFULLSCREEN:
+                return 480 - GetSystemMetrics(SM_CYMIN);
         }
     }
         


### PR DESCRIPTION
works around https://github.com/otya128/winevdm/issues/523#issuecomment-653306234