### PR TITLE
if getprofilestring returns a path convert it to a short path

### DIFF
--- a/krnl386/file.c
+++ b/krnl386/file.c
@@ -438,6 +438,12 @@ INT16 WINAPI GetProfileString16( LPCSTR section, LPCSTR entry, LPCSTR def_val,
         }
         ret = strlen(buffer);
     }
+    else if (ret && PathFileExistsA(buffer))
+    {
+        int cnt = GetShortPathNameA(buffer, tmp, len <= 256 ? len : 256);
+        if (cnt)
+            strcpy(buffer, tmp);
+    }
     return ret;
 }
 


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/738