### PR TITLE
clamp getfreespace at 100MB

### DIFF
--- a/krnl386/global.c
+++ b/krnl386/global.c
@@ -1071,7 +1071,7 @@ DWORD WINAPI GetFreeSpace16( UINT16 wFlags )
 {
     MEMORYSTATUS ms;
     GlobalMemoryStatus( &ms );
-    return ms.dwAvailVirtual;
+    return min(ms.dwAvailVirtual, 102400000);
 }
 
 /***********************************************************************

--- a/krnl386/int31.c
+++ b/krnl386/int31.c
@@ -1337,10 +1337,10 @@ void WINAPI DOSVM_Int31Handler( CONTEXT *context )
             NtQuerySystemInformation( SystemBasicInformation, &sbi, sizeof(sbi), NULL );
 
             info->wPageSize            = sbi.PageSize;
-            info->dwLargestFreeBlock   = status.dwAvailVirtual;
+            info->dwLargestFreeBlock   = min(status.dwAvailVirtual, 102400000);
             info->dwMaxPagesAvailable  = info->dwLargestFreeBlock / info->wPageSize;
             info->dwMaxPagesLockable   = info->dwMaxPagesAvailable;
-            info->dwTotalLinearSpace   = status.dwTotalVirtual / info->wPageSize;
+            info->dwTotalLinearSpace   = min(status.dwTotalVirtual, 102400000) / info->wPageSize;
             info->dwTotalUnlockedPages = info->dwTotalLinearSpace;
             info->dwFreePages          = info->dwMaxPagesAvailable;
             info->dwTotalPages         = info->dwTotalLinearSpace;


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/760

ntvdm uses 102400000 as the max so I set it to that.