### PR TITLE
use getfileresource16 instead of getfileversioninfoA and sizeA

### DIFF
--- a/ver/version.c
+++ b/ver/version.c
@@ -29,6 +29,7 @@
 
 #include "windef.h"
 #include "wine/winbase16.h"
+#include "winuser.h"
 #include "winver.h"
 #include "lzexpand.h"
 #include "wine/unicode.h"
@@ -507,13 +508,14 @@ DWORD WINAPI GetFileVersionInfoSize16( LPCSTR lpszFileName, LPDWORD lpdwHandle )
 {
     BOOL ret;
     TRACE("(%s, %p)\n", debugstr_a(lpszFileName), lpdwHandle );
-    ret = GetFileVersionInfoSizeA( lpszFileName, lpdwHandle );
+    ret = GetFileResourceSize16( lpszFileName, VS_FILE_INFO, VS_VERSION_INFO, NULL );
     if (!ret)
     {
         char path[MAX_PATH];
         if (findfile( lpszFileName, path, MAX_PATH ))
-            ret = GetFileVersionInfoSizeA( (LPSTR)path, lpdwHandle );
+            ret = GetFileResourceSize16( lpszFileName, VS_FILE_INFO, VS_VERSION_INFO, NULL );
     }
+    *lpdwHandle = NULL;
     return ret;
 }
 
@@ -527,19 +529,13 @@ DWORD WINAPI GetFileVersionInfo16( LPCSTR lpszFileName, DWORD handle,
     char *buf;
     TRACE("(%s, %08x, %d, %p)\n",
                 debugstr_a(lpszFileName), handle, cbBuf, lpvData );
-    if (!(size = GetFileVersionInfoSize16(lpszFileName, handle)))
-        return 0;
-    buf = (char *)HeapAlloc(GetProcessHeap(), 0, size);
-    ret = GetFileVersionInfoA( lpszFileName, handle, size, (LPVOID)buf );
+    ret = GetFileResource16( lpszFileName, VS_FILE_INFO, VS_VERSION_INFO, NULL, cbBuf, lpvData );
     if (!ret)
     {
         char path[MAX_PATH];
-        if (findfile( lpszFileName, path, MAX_PATH ));
-            ret = GetFileVersionInfoA( (LPSTR)path, handle, size, (LPVOID)buf );
+        if (findfile( lpszFileName, path, MAX_PATH ))
+            ret = GetFileResource16( lpszFileName, VS_FILE_INFO, VS_VERSION_INFO, NULL, cbBuf, lpvData );
     }
-    if (ret)
-        memcpy(lpvData, buf, min(size, cbBuf));
-    HeapFree(GetProcessHeap(), 0, buf);
     return ret;
 }
 


### PR DESCRIPTION
GetfileversioninfosizeA doesn't return the correct size (maybe it's reserving space for unicode conversion?) which makes getfileversioninfoA not work right either. Since getfileresourcesize16 and getfileresource16 are right there just use them.

fixes https://github.com/otya128/winevdm/issues/733