### PR TITLE
dispatch wm_timer messages in peekmessage that have null hwnd so need…

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -2866,6 +2866,12 @@ BOOL16 WINAPI PeekMessage32_16( MSG32_16 *msg16, HWND16 hwnd16,
         MsgWaitForMultipleObjectsEx( 0, NULL, 0, 0, MWMO_ALERTABLE );
     if (!PeekMessageA( &msg, hwnd, first, last, flags )) return FALSE;
 
+    if ((flags & PM_REMOVE) && !msg.hwnd && (msg.message == WM_TIMER))
+    {
+        DispatchMessageA(&msg);
+        return PeekMessage32_16(msg16, hwnd16, first, last, flags, wHaveParamHigh);
+    }
+
     if (atom_UserAdapterWindowClass == 0)
     {
         WNDCLASSA c;


### PR DESCRIPTION
… to be passed to a callback

fixes crash in https://github.com/otya128/winevdm/issues/755 caused by waveout timer messages somehow in the main thread queue (in windows 10, this doesn't happen in windows 7 or xp).  If this causes regressions it might be necessary to track timers created in win16 and only dispatch those for win32 code.