### PR TITLE
if the vm is entered with an invalid ds, zero it

### DIFF
--- a/vm86/msdos.cpp
+++ b/vm86/msdos.cpp
@@ -1483,7 +1483,7 @@ extern "C"
 			SREG(ES) = (WORD)context->SegEs;
 			SREG(CS) = (WORD)context->SegCs;
 			SREG(SS) = (WORD)context->SegSs;
-			SREG(DS) = (WORD)context->SegDs;
+			SREG(DS) = wine_ldt_copy.flags[(WORD)context->SegDs >> 3] & WINE_LDT_FLAGS_ALLOCATED ? (WORD)context->SegDs : 0;
             /* Some programs expect that gs is not a valid selector! */
             /* Some programs expect that fs is not a valid selector! */
             SREG(FS) = (WORD)context->SegFs == reg_fs ? 0 : context->SegFs;

--- a/whpxvm/whpxvm.c
+++ b/whpxvm/whpxvm.c
@@ -1058,6 +1058,8 @@ void vm86main(CONTEXT *context, DWORD csip, DWORD sssp, DWORD cbArgs, PEXCEPTION
             load_seg(&state.ss, (WORD)SELECTOROF(sssp));
             state.rip.Reg32 = OFFSETOF(csip);
             state.rsp.Reg32 = OFFSETOF(sssp) - cbArgs;
+            if (!wine_ldt_copy.flags[(WORD)context->SegDs >> 3] & WINE_LDT_FLAGS_ALLOCATED)
+                load_seg(&state.ds, (WORD)0);
         }
         if (FAILED(result = pWHvSetVirtualProcessorRegisters(partition, 0, whpx_vcpu_reg_names, ARRAYSIZE(whpx_vcpu_reg_names), state.values)))
         {

--- a/whpxvm/whpxvm.c
+++ b/whpxvm/whpxvm.c
@@ -1058,7 +1058,7 @@ void vm86main(CONTEXT *context, DWORD csip, DWORD sssp, DWORD cbArgs, PEXCEPTION
             load_seg(&state.ss, (WORD)SELECTOROF(sssp));
             state.rip.Reg32 = OFFSETOF(csip);
             state.rsp.Reg32 = OFFSETOF(sssp) - cbArgs;
-            if (!wine_ldt_copy.flags[(WORD)context->SegDs >> 3] & WINE_LDT_FLAGS_ALLOCATED)
+            if (!(wine_ldt_copy.flags[state.ds.Segment.Selector >> 3] & WINE_LDT_FLAGS_ALLOCATED))
                 load_seg(&state.ds, (WORD)0);
         }
         if (FAILED(result = pWHvSetVirtualProcessorRegisters(partition, 0, whpx_vcpu_reg_names, ARRAYSIZE(whpx_vcpu_reg_names), state.values)))


### PR DESCRIPTION
this is a workaround for when vm_inject is called from a timer thread and the context contains freed selectors
fixes https://github.com/otya128/winevdm/issues/792