### PR TITLE
don't call globalfree in freeresource

### DIFF
--- a/krnl386/resource.c
+++ b/krnl386/resource.c
@@ -1036,7 +1036,7 @@ HGLOBAL16 WINAPI LoadResource16( HMODULE16 hModule, HRSRC16 hRsrc )
 
     if (pNameInfo)
     {
-        if (pNameInfo->handle && !(GlobalFlags16(pNameInfo->handle) & GMEM_DISCARDED))
+        if (pNameInfo->handle && GlobalHandle16(pNameInfo->handle) && !(GlobalFlags16(pNameInfo->handle) & GMEM_DISCARDED))
         {
             pNameInfo->usage++;
             TRACE("  Already loaded, new count=%d\n", pNameInfo->usage );
@@ -1149,12 +1149,6 @@ BOOL16 WINAPI FreeResource16( HGLOBAL16 handle )
                         {
                             return handle;
                         }
-                    }
-                    if (pNameInfo->usage == 0)
-                    {
-                        GlobalFree16( pNameInfo->handle );
-                        pNameInfo->handle = 0;
-                        pNameInfo->flags &= ~NE_SEGFLAGS_LOADED;
                     }
                     return FALSE;
                 }


### PR DESCRIPTION
This fixes the quicktime installer (https://github.com/otya128/winevdm/issues/803) which loads a dialog resource, frees it and tries to use it later.  https://github.com/otya128/winevdm/issues/756 still works too since it calls globalfree on the resource after freeing it.  It seems windows will discard a resource when freed but will reload it with the same global handle.  This will break if something frees a resource then the handle is reallocated then the resource is reloaded (windows itself may not handle that case properly either though).