### PR TITLE
handle exception in gettextextent

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -2352,7 +2352,15 @@ DWORD WINAPI GetTextExtent16( HDC16 hdc, LPCSTR str, INT16 count )
 {
     SIZE size;
     HDC hdc32 = HDC_32(hdc);
-    if (!GetTextExtentPoint32A( hdc32, str, count, &size )) return 0;
+    __TRY
+    {
+        if (!GetTextExtentPoint32A( hdc32, str, count, &size )) return 0;
+    }
+    __EXCEPT_ALL
+    {
+        return 0;
+    }
+    __ENDTRY
     check_font_rotation( hdc32, &size ); 
     return MAKELONG( size.cx, size.cy );
 }


### PR DESCRIPTION
Ntvdm returns 0 if the string pointer is invalid.  It seems that functions that existed in real mode windows silently handle exceptions for compatibility reasons.