### PR TITLE
disable the update in animatepallete

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -3472,7 +3472,7 @@ void WINAPI AnimatePalette16( HPALETTE16 hpalette, UINT16 StartIndex,
             {
                 HWND hwnd = HWND_32(hwlist[i]);
                 InvalidateRect(hwnd, NULL, FALSE);
-                UpdateWindow(hwnd);
+                //UpdateWindow(hwnd);
             }
         }
     }


### PR DESCRIPTION
This fixes https://github.com/otya128/winevdm/issues/803 although it still has some minor graphics corruption.  It break the fadeout in gabriel knight but it still seems to work okay.  This might end up needing some kind of mode switch, an interface for that with more functionality than the compatibility property page might be useful.