### PR TITLE
return error_lock_violation from unlock file instead of error_not_locked

### DIFF
--- a/krnl386/int21.c
+++ b/krnl386/int21.c
@@ -5331,7 +5331,11 @@ void WINAPI DOSVM_Int21Handler( CONTEXT *context )
                 TRACE( "unlock handle %d offset %d length %d\n",
                        BX_reg(context), offset, length );
                 if (!UnlockFile( handle, offset, 0, length, 0 ))
+                {
                     bSetDOSExtendedError = TRUE;
+                    if (GetLastError() == ERROR_NOT_LOCKED)
+                        SetLastError(ERROR_LOCK_VIOLATION);
+                }
                 break;
 
             default:


### PR DESCRIPTION
This likely fixes https://github.com/otya128/winevdm/issues/830 but making it a draft until tested.