### PR TITLE
handle file reads to address 0 and more invalid offset for real mode …

### DIFF
--- a/krnl386/int21.c
+++ b/krnl386/int21.c
@@ -4921,7 +4921,14 @@ void WINAPI DOSVM_Int21Handler( CONTEXT *context )
             /* Some programs pass a count larger than the allocated buffer */
             if (DOSVM_IsWin16())
             {
-                DWORD maxcount = GetSelectorLimit16( context->SegDs )
+                WORD sel = context->SegDs;
+                if (!sel)
+                {
+                    buffer = MapSL(MAKELONG(context->Edx & 0xffff, DOSMEM_0000H));
+                    sel = DOSMEM_0000H;
+                }
+
+                DWORD maxcount = GetSelectorLimit16( sel )
                     - DX_reg(context) + 1;
                 if (count > maxcount)
                     count = maxcount;

--- a/rmpatch/instr.c
+++ b/rmpatch/instr.c
@@ -583,11 +583,18 @@ BOOL rmpatch_emulate_instruction(CONTEXT *context)
                 if (instr[1] & 0x38)
                     break;
                 BYTE *addr = INSTR_GetOperandAddr(context, instr + 1, segprefix, &len);
-                switch (*instr)
+                __TRY
                 {
-                    case 0xc6: *addr = instr[2]; break;
-                    case 0xc7: *(WORD *)addr = instr[2] | (instr[3] << 8); break;
+                    switch (*instr)
+                    {
+                        case 0xc6: *addr = instr[2]; break;
+                        case 0xc7: *(WORD *)addr = instr[2] | (instr[3] << 8); break;
+                    }
                 }
+                __EXCEPT_ALL
+                {
+                }
+                __ENDTRY
                 context->Eip += prefixlen + ((*instr == 0xc7) ? 2 : 1) + len + 1;
                 return TRUE;
             }


### PR DESCRIPTION
…programs

fixes https://github.com/otya128/winevdm/issues/811

The program actually does overwrite the int 0 handler in win1/2 and win31 standard mode where the read is handled in real mode.