### PR TITLE
set numcolors to always be 20 and more msvideo fixes

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -2114,14 +2114,8 @@ INT16 WINAPI GetDeviceCaps16( HDC16 hdc, INT16 cap )
                 ret |= RC_PALETTE;
                 break;
             case NUMCOLORS:
-            {
-                HPALETTE pal = GetCurrentObject(hdc32, OBJ_PAL);
-                if (pal)
-                    ret = GetPaletteEntries(pal, 0, 0, NULL);
-                else
-                    ret = 256;
+                ret = 20;
                 break;
-            }
         }
     }
     else if ((cap == NUMCOLORS) && (ret == -1)) ret = 2048;

--- a/vm86/msdos.cpp
+++ b/vm86/msdos.cpp
@@ -2081,7 +2081,7 @@ ES:%04X,CS:%04X,SS:%04X,DS:%04X,FS:%04X,GS:%04X\n\
 IP:%04X, address:%08X\n\
 EFLAGS:%08X\
 \n\n%s\n", rec->ExceptionAddress, (void*)rec->ExceptionInformation[1],
-REG32(EAX), REG32(ECX), REG32(EDX), REG32(EBX), REG32(ESP), REG16(BP), REG16(SI), REG16(DI),
+REG32(EAX), REG32(ECX), REG32(EDX), REG32(EBX), REG32(ESP), REG32(EBP), REG32(ESI), REG32(EDI),
 SREG(ES), SREG(CS), SREG(SS), SREG(DS), SREG(FS), SREG(GS), m_eip, m_pc, m_eflags, buf_pre);
         dump_all_modules();
         dump_stack_trace();


### PR DESCRIPTION
Testing shows that getdevcaps(numcolors) always is 20 in 8bpp mode even if a larger palette is selected and realized.
fixes https://github.com/otya128/winevdm/issues/835