### PR TITLE
if localinit is called in localalloc, get the new heap pointer

### DIFF
--- a/krnl386/local.c
+++ b/krnl386/local.c
@@ -945,6 +945,7 @@ static HLOCAL16 LOCAL_GetBlock( HANDLE16 ds, DWORD size, WORD flags )
         {
             LocalInit16(ds, addr & 0xFFFF, (addr & 0xFFFF) + GlobalSize16(ds));
             GlobalUnlock16(ds);
+            pInfo = LOCAL_GetHeap(ds);
         }
         else
         {


### PR DESCRIPTION
dtools calls localalloc with a selector that needs localinit and enlargement.  pInfo is then null when new_heap_size is calculated.