### PR TITLE
use sendmessagecallback to make sure the message is in the dest threa…

### DIFF
--- a/krnl386/ne_module.c
+++ b/krnl386/ne_module.c
@@ -2057,8 +2057,16 @@ HINSTANCE16 WINAPI WinExec16(LPCSTR lpCmdLine, UINT16 nCmdShow)
             {
                 DWORD count;
                 struct kernel_thread_data *chdthd = (struct kernel_thread_data *)TebTlsGetValue(curtdb->teb, kernel_thread_data_tls);
+                MSG msg;
+                DWORD timeout = GetTickCount() + 30000;
                 ReleaseThunkLock(&count);
-                WaitForSingleObject(chdthd->idle_event, 30000);
+                do
+                {
+                    DWORD wret = MsgWaitForMultipleObjects(1, &chdthd->idle_event, FALSE, timeout - GetTickCount(), QS_SENDMESSAGE);
+                    if ((wret != (WAIT_OBJECT_0 + 1)) || (GetTickCount() >= timeout))
+                        break;
+                    PeekMessage(&msg, NULL, 0, 0, PM_REMOVE | PM_QS_SENDMESSAGE);
+                } while (1);
                 RestoreThunkLock(count);
                 GlobalUnlock16(curtask);
                 break;

--- a/krnl386/ne_module.c
+++ b/krnl386/ne_module.c
@@ -2063,10 +2063,10 @@ HINSTANCE16 WINAPI WinExec16(LPCSTR lpCmdLine, UINT16 nCmdShow)
                 do
                 {
                     DWORD wret = MsgWaitForMultipleObjects(1, &chdthd->idle_event, FALSE, timeout - GetTickCount(), QS_SENDMESSAGE);
-                    if ((wret != (WAIT_OBJECT_0 + 1)) || (GetTickCount() >= timeout))
+                    if (wret != (WAIT_OBJECT_0 + 1))
                         break;
                     PeekMessage(&msg, NULL, 0, 0, PM_REMOVE | PM_QS_SENDMESSAGE);
-                } while (1);
+                } while (GetTickCount() < timeout);
                 RestoreThunkLock(count);
                 GlobalUnlock16(curtask);
                 break;

--- a/user/message.c
+++ b/user/message.c
@@ -2810,12 +2810,13 @@ static LRESULT send_message_callback_callback( HWND hwnd, UINT msg, WPARAM wp, L
         {
             MSG msg;
             DWORD ret = MsgWaitForMultipleObjects(1, &args.event, FALSE, timeout - GetTickCount(), QS_ALLINPUT);
-            if ((ret != (WAIT_OBJECT_0 + 1)) || (GetTickCount() >= timeout))
+            if (ret != (WAIT_OBJECT_0 + 1))
                 break;
             PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE);
-        } while(1);
+        } while(GetTickCount() < timeout);
         RestoreThunkLock(count);
     }
+    args.magic = 0;
     CloseHandle(args.event);
     return TRUE;
 }


### PR DESCRIPTION
…d queue before releasing the win16 lock and don't release the idle lock in sendmessage instead check for sent messages in winexec

fixes https://github.com/otya128/winevdm/issues/609
Reactos WaitForInputIdle also does PM_QS_SENDMESSAGE and it makes the wp macro work.  The sendmessagecallback part makes wp start more reliable as currently it crashes reliably when started with a trace log.