### PR TITLE
create idle event to indicate no running threads

### DIFF
--- a/krnl386/kernel.c
+++ b/krnl386/kernel.c
@@ -37,6 +37,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(module);
 extern DWORD WINAPI GetProcessFlags( DWORD processid );
 
 static DWORD process_dword;
+extern HANDLE vm_idle_event;
 
 DWORD kernel_thread_data_tls = TLS_OUT_OF_INDEXES;
 /***********************************************************************
@@ -233,6 +234,8 @@ BOOL WINAPI KERNEL_DllEntryPoint( DWORD reasion, HINSTANCE16 inst, WORD ds,
     func_wine_call_to_16_vm86 = (wine_call_to_16_vm86_t)GetProcAddress(vm, "wine_call_to_16_vm86");
     func_wine_call_to_16_regs_vm86 = (wine_call_to_16_regs_vm86_t)GetProcAddress(vm, "wine_call_to_16_regs_vm86");
     RtlAddVectoredExceptionHandler(FALSE, fflush_vectored_handler);
+
+    vm_idle_event = CreateEvent(NULL, TRUE, TRUE, NULL);
     return TRUE;
 }
 

--- a/krnl386/krnl386.def
+++ b/krnl386/krnl386.def
@@ -241,3 +241,4 @@ EXPORTS
   GLOBAL_FindLink
   vm_inject
   set_vm_inject_cb
+  get_idle_event

--- a/krnl386/krnl386.exe16.spec
+++ b/krnl386/krnl386.exe16.spec
@@ -796,3 +796,4 @@
 @ cdecl -arch=win32 GLOBAL_FindLink(long)
 @ stdcall -arch=win32 set_vm_inject_cb(long)
 @ stdcall -arch=win32 vm_inject(long long long long long)
+@ stdcall -arch=win32 get_idle_event()

--- a/vm86/msdos.cpp
+++ b/vm86/msdos.cpp
@@ -978,6 +978,7 @@ extern "C"
     typedef VOID (WINAPI *GetpWin16Lock_t)(SYSLEVEL **lock);
     GetpWin16Lock_t pGetpWin16Lock;
     SYSLEVEL *win16_syslevel;
+    HANDLE *vm_idle_event;
     typedef BOOL(WINAPI *WOWCallback16Ex_t)(DWORD vpfn16, DWORD dwFlags,
         DWORD cbArgs, LPVOID pArgs, LPDWORD pdwRetCode);
     WOWCallback16Ex_t pWOWCallback16Ex;
@@ -1009,6 +1010,8 @@ extern "C"
         pGetpWin16Lock = (GetpWin16Lock_t)GetProcAddress(krnl386, "GetpWin16Lock");
         pGetpWin16Lock(&win16_syslevel);
         pWOWCallback16Ex = (WOWCallback16Ex_t)GetProcAddress(krnl386, "K32WOWCallback16Ex");
+        HANDLE *(WINAPI *get_idle_event)() = (HANDLE *(WINAPI *)())GetProcAddress(krnl386, "get_idle_event");
+        vm_idle_event = get_idle_event();
         //SetConsoleCtrlHandler(dump, TRUE);
 		AddVectoredExceptionHandler(TRUE, vm86_vectored_exception_handler);
 		WORD sel = SELECTOR_AllocBlock(iret, 256, WINE_LDT_FLAGS_CODE);
@@ -1392,7 +1395,7 @@ try_again:
             ResetEvent(inject_event);
         }
         LeaveCriticalSection(&inject_crit_section);
-        HANDLE objs[2] = { inject_event, win16_syslevel->crst.LockSemaphore };
+        HANDLE objs[2] = { inject_event, vm_idle_event };
         DWORD ret = WaitForMultipleObjects(2, objs, FALSE, INFINITE);
         if (ret == (WAIT_OBJECT_0 + 1))
         {


### PR DESCRIPTION
https://github.com/otya128/winevdm/pull/847 was completely broken on vista+ because the event was removed from most critical sections.  This creates an event specifically for when the vm is completely idle.