### PR TITLE
add syskey(up/down) to journalplayback for msaccess basic sendkeys

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -2798,6 +2798,19 @@ HDC16 WINAPI CreateIC16( LPCSTR driver, LPCSTR device, LPCSTR output,
         if (GetDefaultPrinterA(tmp, &len))
             device = tmp;
     }
+    if (initData && (!driver || !stricmp(driver, "winspool")))
+    {
+        DEVMODEA dma = {0};
+        if (!IsValidDevmodeA(initData, initData->dmSize + initData->dmDriverExtra))
+            initData = NULL;
+        else
+        {
+            memcpy(&dma, initData, initData->dmSize);
+            dma.dmSize = sizeof(DEVMODEA);
+            dma.dmDriverExtra = 0;
+            return HDC_16( CreateICA( driver, device, output, &dma ) );
+        }
+    }
     return HDC_16( CreateICA( driver, device, output, initData ) );
 }
 

--- a/user/hook.c
+++ b/user/hook.c
@@ -809,6 +809,7 @@ static void WINAPI journal_playback_cb( HWND hwnd, UINT msg, UINT_PTR id, DWORD 
                 PostThreadMessage(GetCurrentThreadId(), WM_QUEUESYNC, 0, NULL);
                 break;
             case WM_KEYDOWN:
+            case WM_SYSKEYDOWN:
                 input.type = 1;
                 input.ki.wVk = emsg.paramL;
                 input.ki.wScan = emsg.paramH;
@@ -818,6 +819,7 @@ static void WINAPI journal_playback_cb( HWND hwnd, UINT msg, UINT_PTR id, DWORD 
                 SendInput( 1, &input, sizeof(input) );
                 break;
             case WM_KEYUP:
+            case WM_SYSKEYUP:
                 input.type = 1;
                 input.ki.wVk = emsg.paramL;
                 input.ki.wScan = emsg.paramH;

--- a/user/message.c
+++ b/user/message.c
@@ -1926,6 +1926,14 @@ LRESULT WINPROC_CallProc16To32A( winproc_callback_t callback, HWND16 hwnd, UINT1
     case WM_DROPFILES:
         ret = callback(hwnd32, msg, (WPARAM)hdrop16_to_hdrop32((HDROP16)wParam), lParam, result, arg);
         break;
+    case WM_SETREDRAW:
+    {
+        BOOL redraw = !(GetWindowLongA(hwnd32, GWL_STYLE) & WS_VISIBLE);
+        ret = callback(hwnd32, msg, wParam, lParam, result, arg);
+        if (redraw)
+            RedrawWindow(hwnd32, NULL, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
+        break;
+    }
     default:
     {
         if (msg != WM_NULL && msg == drag_list_message)


### PR DESCRIPTION
seems to fix otya128/winevdm#852

The wm_setredraw problem doesn't happen in winxp even with winevdm so it's likely a dwm problem.  All children need it to otherwise the problem still happens with popup dialogs.
