### PR TITLE
if windowproc16 is called with wm_create for the native mdiclient pro…

### DIFF
--- a/olecli/olecli.c
+++ b/olecli/olecli.c
@@ -509,11 +509,14 @@ OLESTATUS WINAPI OleActivate16(SEGPTR oleobj, UINT uint, BOOL b1, BOOL b2, HWND1
 {
     LPOLEOBJECT oleobj32 = OLEOBJ32(oleobj);
     RECT rect32;
+    DWORD count;
     if (rect)
     {
         RECT16to32(rect, &rect32);
     }
+    ReleaseThunkLock(&count);
     OLESTATUS status = OleActivate(oleobj32, uint, b1, b2, HWND_32(hwnd), rect ? &rect32 : NULL);
+    RestoreThunkLock(count);
     return status;
 }
 

--- a/olecli/olecli.c
+++ b/olecli/olecli.c
@@ -712,15 +712,17 @@ OLESTATUS WINAPI OleGetData16(SEGPTR oleobj16, OLECLIPFORMAT fmt, HANDLE16 *hand
         FIXME("unknown format %04x\n", fmt);
     }
     result = OleGetData(oleobj, fmt, &handle32);
-    if (result == OLE_OK && handle32)
+    if ((result == OLE_OK || result == OLE_WARN_DELETE_DATA) && handle32)
     {
         SIZE_T size = GlobalSize(handle32);
         HGLOBAL16 handle16 = GlobalAlloc16(GMEM_MOVEABLE, size);
         *handle = handle16;
         LPVOID mem = GlobalLock16(handle16);
         memcpy(mem, GlobalLock(handle32), size);
-        GlobalFree(handle32);
+        if (result == OLE_WARN_DELETE_DATA)
+            GlobalFree(handle32);
         GlobalUnlock16(handle16);
+        return OLE_WARN_DELETE_DATA;  // hopefully the client will free the handle
     }
     return result;
 }

--- a/user/message.c
+++ b/user/message.c
@@ -5028,6 +5028,7 @@ LRESULT CALLBACK WindowProc16(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam)
     if (wndproc16)
     {
         MSG msg = { 0 };
+        CLIENTCREATESTRUCT c32;
         msg.hwnd = hDlg;
         msg.message = Msg;
         msg.wParam = wParam;
@@ -5039,6 +5040,13 @@ LRESULT CALLBACK WindowProc16(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam)
             if (index >= MAX_WINPROCS32)
                 index -= MAX_WINPROCS32;
             WNDPROC wndproc32 = winproc16_array[index];
+            if ((Msg == WM_CREATE) && is_mdiclient(hWnd16, hDlg))
+            {
+                CLIENTCREATESTRUCT16 *c16 = MapSL(*(DWORD *)lParam);
+                c32.idFirstChild = c16->idFirstChild;
+                c32.hWindowMenu = HMENU_32(c16->hWindowMenu);
+                ((CREATESTRUCTA *)lParam)->lpCreateParams = (LPVOID)&c32;
+            }
             return CallWindowProcA(wndproc32, hDlg, Msg, wParam, lParam);
         }
         WINPROC_CallProc32ATo16(call_window_proc16, msg.hwnd, msg.message, msg.wParam, msg.lParam,


### PR DESCRIPTION
…c then convert the clientcreatestruct; also release the win16 lock around oleactivate

Fixes a hang and crash in sqlwindows ole sample.  If Olegetdata returns OLE_WARN_DELETE_DATA it's supposed to free the memory so try returning that all the time to prevent the global handle leak.