### PR TITLE
return caller cs in dx from freelibrary16

### DIFF
--- a/krnl386/krnl386.exe16.spec
+++ b/krnl386/krnl386.exe16.spec
@@ -97,7 +97,7 @@
 93  pascal GetCodeHandle(segptr) GetCodeHandle16
 94  pascal -ret16 DefineHandleTable(word) DefineHandleTable16
 95  pascal -ret16 LoadLibrary(str) LoadLibrary16
-96  pascal -ret16 FreeLibrary(word) FreeLibrary16
+96  pascal FreeLibrary(word) WIN16_FreeLibrary16
 97  pascal -ret16 GetTempFileName(word str word ptr) GetTempFileName16
 98  pascal -ret16 GetLastDiskChange() KERNEL_nop
 99  stub GetLPErrMode

--- a/krnl386/ne_module.c
+++ b/krnl386/ne_module.c
@@ -1706,6 +1706,11 @@ BOOL16 WINAPI FreeModule16( HMODULE16 hModule )
     return NE_FreeModule( hModule, TRUE );
 }
 
+DWORD WINAPI WIN16_FreeLibrary16(HINSTANCE16 handle)
+{
+    FreeLibrary16(handle);
+    return MAKELONG(0, CURRENT_STACK16->cs);
+}
 
 /***********************************************************************
  *           FreeLibrary     (KERNEL.96)


### PR DESCRIPTION
fixes wpwin 5.2 printing (seriously).  verified with ntvdm.