### PR TITLE
if the command line is null return 0 for the length

### DIFF
--- a/otvdm/winevdm.c
+++ b/otvdm/winevdm.c
@@ -48,6 +48,8 @@ static char *build_command_line( char **argv )
     int len;
     char *p, **arg, *cmd_line;
 
+    if (!argv[0])
+        return "";
     len = 0;
     for (arg = argv; *arg; arg++)
     {


### PR DESCRIPTION
this happens when run from ntvdm64 it'll return 255 for len and overruns the buffer at https://github.com/otya128/winevdm/blob/master/krnl386/task.c#L406