### PR TITLE
limit lpstrfile in commdlg

### DIFF
--- a/commdlg/filedlg.c
+++ b/commdlg/filedlg.c
@@ -296,8 +296,8 @@ BOOL16 WINAPI GetOpenFileName16( SEGPTR ofn ) /* [in/out] address of structure w
         }
     }
 
-    if (ofn32.lpstrFile)
-        CharUpperBuffA(ofn32.lpstrFile, ofn32.nMaxFile);
+    if (ofn32.lpstrFile && ofn32.lpstrFile[0])
+        CharUpperBuffA(ofn32.lpstrFile, min(strlen(ofn32.lpstrFile), ofn32.nMaxFile));
 
     ReleaseThunkLock(&count);
     if ((ret = GetOpenFileNameA( &ofn32 )))
@@ -305,7 +305,7 @@ BOOL16 WINAPI GetOpenFileName16( SEGPTR ofn ) /* [in/out] address of structure w
         lpofn->nFilterIndex   = ofn32.nFilterIndex;
         lpofn->nFileOffset    = ofn32.nFileOffset;
         lpofn->nFileExtension = ofn32.nFileExtension;
-        CharUpperBuffA(ofn32.lpstrFile, ofn32.nMaxFile);
+        CharUpperBuffA(ofn32.lpstrFile, min(strlen(ofn32.lpstrFile), ofn32.nMaxFile));
     }
     RestoreThunkLock(count);
     delete_thunk(ofn32.lpfnHook);
@@ -377,8 +377,8 @@ BOOL16 WINAPI GetSaveFileName16( SEGPTR ofn ) /* [in/out] address of structure w
             ofn32.lpfnHook = dummy_hook;
         }
     }
-    if (ofn32.lpstrFile)
-        CharUpperBuffA(ofn32.lpstrFile, ofn32.nMaxFile);
+    if (ofn32.lpstrFile && ofn32.lpstrFile[0])
+        CharUpperBuffA(ofn32.lpstrFile, min(strlen(ofn32.lpstrFile), ofn32.nMaxFile));
 
     ReleaseThunkLock(&count);
     if ((ret = GetSaveFileNameA( &ofn32 )))
@@ -386,7 +386,7 @@ BOOL16 WINAPI GetSaveFileName16( SEGPTR ofn ) /* [in/out] address of structure w
         lpofn->nFilterIndex   = ofn32.nFilterIndex;
         lpofn->nFileOffset    = ofn32.nFileOffset;
         lpofn->nFileExtension = ofn32.nFileExtension;
-        CharUpperBuffA(ofn32.lpstrFile, ofn32.nMaxFile);
+        CharUpperBuffA(ofn32.lpstrFile, min(strlen(ofn32.lpstrFile), ofn32.nMaxFile));
     }
     RestoreThunkLock(count);
     delete_thunk(ofn32.lpfnHook);

--- a/user/message.c
+++ b/user/message.c
@@ -5094,3 +5094,9 @@ void WINAPI window_message16_32(const MSG16 *msg16, MSG *msg32)
     msg32->time = msg16->time;
     WINPROC_CallProc16To32A(LPMSG16_32_callback, msg16->hwnd, msg16->message, msg16->wParam, msg16->lParam, &ret, msg32);
 }
+
+BOOL16 WINAPI QuerySendMessage16(HANDLE16 res1, HANDLE16 res2, HANDLE16 res3, MSG16 *msg)
+{
+    WARN("not returning message\n");
+    return InSendMessage();
+}

--- a/user/user.c
+++ b/user/user.c
@@ -4336,3 +4336,9 @@ INT16 WINAPI SysErrorBox16(LPCSTR text, LPCSTR caption, UINT16 btn1, UINT16 btn2
     HeapFree(GetProcessHeap(), 0, wcaption);
     return result;
 }
+
+BOOL16 WINAPI LockInput16(HANDLE16 res, HWND16 hwnd, BOOL16 lock)
+{
+    FIXME("(%d, %d, %d) - stub\n", res, hwnd, lock);
+    return FALSE;
+}

--- a/user/user.exe16.spec
+++ b/user/user.exe16.spec
@@ -180,7 +180,7 @@
 181 pascal -ret16 SetSysColors(word ptr ptr) SetSysColors16
 182 pascal -ret16 KillSystemTimer(word word) KillSystemTimer16 # BEAR182
 183 pascal -ret16 GetCaretPos(ptr) GetCaretPos16
-184 stub QuerySendMessage # W1.1, W2.0: SYSHASKANJI
+184 pascal -ret16 QuerySendMessage(word word word ptr) QuerySendMessage16
 185 pascal -ret16 GrayString(word word segptr segptr s_word s_word s_word s_word s_word) GrayString16
 186 pascal -ret16 SwapMouseButton(word) SwapMouseButton16
 187 pascal -ret16 EndMenu() EndMenu
@@ -223,7 +223,7 @@
 223 pascal -ret16 SetKeyboardState(ptr) SetKeyboardState16
 224 pascal -ret16 GetWindowTask(word) GetWindowTask16
 225 pascal -ret16 EnumTaskWindows(word segptr long) EnumTaskWindows16
-226 stub LockInput # not in W2.0
+226 pascal -ret16 LockInput(word word word) LockInput16
 227 pascal -ret16 GetNextDlgGroupItem(word word word) GetNextDlgGroupItem16
 228 pascal -ret16 GetNextDlgTabItem(word word word) GetNextDlgTabItem16
 229 pascal -ret16 GetTopWindow(word) GetTopWindow16


### PR DESCRIPTION
fixes watcom debugger which passes a size larger than the buffer

With the stubs wdw sort of works, it can't load the exports from the pe-ne built in dlls though (it will try to load exports from a copy of the dll from the windows/system dir, dummy or real, it's not correct).  It can see the in memory image (kernel and user are missing?) though.