### PR TITLE
fix stack

### DIFF
--- a/compobj/compobj.c
+++ b/compobj/compobj.c
@@ -885,7 +885,7 @@ HRESULT WINAPI CoGetClassObject16(
         }
 
         dll = LoadLibrary16(dllpath);
-        if (!dll)
+        if (dll < 32)
         {
             ERR("couldn't load in-process dll %s\n", debugstr_a(dllpath));
             err_last = E_ACCESSDENIED16; /* FIXME: or should this be CO_E_DLLNOTFOUND? */

--- a/win87em/win87em.c
+++ b/win87em/win87em.c
@@ -195,7 +195,7 @@ void WINAPI fpe_return(CONTEXT *context)
     context->Eip = stkptr[5];
     context->SegCs = stkptr[6];
     context->EFlags = stkptr[7];
-    context->Esp -= 16;
+    context->Esp += 16;
 }
 
 static void WINAPI fpu_exception(CONTEXT *context)


### PR DESCRIPTION
Fixes Netscape 4.  There's another issue where an unmasked x87 exception occurs which is caused by a conversion of nan into an int.  The Netscape exception handler ignores it and winevdm (which can't do anything about it in whpx on intel for the same reason that it crashes in qemu whpx, the fds deprecation).  Qemu and Dosbox in emulation doesn't get an exception there so it needs testing on a machine without fds deprecation or an emulator that does fpu exceptions properly.

Edit: Invalid exceptions seem only forced to unmask for stack faults if win87em is configured to spill the stack which most (hopefully all) don't use.  If the program asks for invalid exceptions to be masked, it's fpe handler isn't called.  We don't handle the stack so I added a message for that.