### PR TITLE
Xerox presents fixes

### DIFF
--- a/krnl386/resource.c
+++ b/krnl386/resource.c
@@ -1170,7 +1170,7 @@ BOOL16 WINAPI FreeResource16( HGLOBAL16 handle )
         args[1] = handle;
         args[0] = 1;  /* CID_RESOURCE */
         WOWCallback16Ex( (SEGPTR)proc, WCB16_PASCAL, sizeof(args), args, &result );
-        return LOWORD(result);
+        return LOWORD(result) ? 0 : 1;
     }
     else
         return GlobalFree16( handle );

--- a/user/message.c
+++ b/user/message.c
@@ -3185,6 +3185,12 @@ LRESULT WINAPI DefWindowProc16( HWND16 hwnd16, UINT16 msg, WPARAM16 wParam, LPAR
 {
     LRESULT result;
     WINPROC_CallProc16To32A(defwindow_proc_callback, hwnd16, msg, wParam, lParam, &result, 0);
+    if ((msg == WM_WINDOWPOSCHANGED) && IsOldWindowsTask(GetCurrentTask()))
+    {
+        WINDOWPOS16 *wpos = (WINDOWPOS16 *)MapSL(lParam);
+        if (wpos->flags & 0x1000 /*SWP_NOCLIENTMOVE*/)
+            SendMessage16(hwnd16, WM_MOVE, 0, MAKELONG(wpos->x, wpos->y));
+    }
     return result;
 }
 


### PR DESCRIPTION
first fixes the tools menu position as wm_move is always sent if the parent moves (wm_windowposchanged doesn't exist on win1 and 2) and second fixes it's exit which loops over the return from freeresource until its 0.