### PR TITLE
don't pass the com port to buildcommdcb and skip the punctuation afte…

### DIFF
--- a/user/comm.c
+++ b/user/comm.c
@@ -336,6 +336,14 @@ INT16 WINAPI BuildCommDCB16(LPCSTR device, LPDCB16 lpdcb)
 		ERR("BUG ! COM0 can't exist!\n");
 		return -1;
 	}
+	device += 4;
+	do
+	{
+		if (!*device)
+			return -1;
+		device++;
+	}
+	while (!isalnum(*device));
 
 	memset(lpdcb, 0, sizeof(DCB16)); /* initialize */
 

--- a/user/comm.c
+++ b/user/comm.c
@@ -345,8 +345,6 @@ INT16 WINAPI BuildCommDCB16(LPCSTR device, LPDCB16 lpdcb)
 	}
 	while (!isalnum(*device));
 
-	memset(lpdcb, 0, sizeof(DCB16)); /* initialize */
-
 	lpdcb->Id = port;
 	dcb.DCBlength = sizeof(DCB);
 
@@ -385,7 +383,7 @@ INT16 WINAPI OpenComm16(LPCSTR device,UINT16 cbInQueue,UINT16 cbOutQueue)
 		handle = CreateFileA(device, GENERIC_READ|GENERIC_WRITE,
 			0, NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, 0 );
 		if (handle == INVALID_HANDLE_VALUE) {
-			ERR("Open %s failed Err %d", device, GetLastError());
+			ERR("Open %s failed Err %d\n", device, GetLastError());
 			return IE_HARDWARE;
 		} else {
 			memset(COM[port].unknown, 0, sizeof(COM[port].unknown));


### PR DESCRIPTION
…r it

fixes https://github.com/otya128/winevdm/issues/917
Windows checks the com port in the string exists but ntvdm works even if it doesn't (except com0 fails).  Ntvdm also doesn't require a colon afterward like the trace from #917 shows a comma is used there.