### PR TITLE
if resource refcount is 0 load a new copy of the resource in loadreso…

### DIFF
--- a/krnl386/resource.c
+++ b/krnl386/resource.c
@@ -1036,7 +1036,7 @@ HGLOBAL16 WINAPI LoadResource16( HMODULE16 hModule, HRSRC16 hRsrc )
 
     if (pNameInfo)
     {
-        if (pNameInfo->handle && GlobalHandle16(pNameInfo->handle) && !(GlobalFlags16(pNameInfo->handle) & GMEM_DISCARDED))
+        if (pNameInfo->handle && GlobalHandle16(pNameInfo->handle) && !(GlobalFlags16(pNameInfo->handle) & GMEM_DISCARDED) && pNameInfo->usage)
         {
             pNameInfo->usage++;
             TRACE("  Already loaded, new count=%d\n", pNameInfo->usage );


### PR DESCRIPTION
…urce

word setup loads a resource, modifies it, frees it and loads it again expecting the modification to be undone.  ntvdm appears to discard the resource eventually also or at least unmaps it.

fixes https://github.com/otya128/winevdm/issues/931