### PR TITLE
make imessagefilter::handleincomingcall default SERVERCALL_ISHANDLED

### DIFF
--- a/ole2/ifs_thunk.c
+++ b/ole2/ifs_thunk.c
@@ -1951,3 +1951,29 @@ DWORD __stdcall OLESTREAM32_32_16_Put(OLESTREAM32 *This, const void *lpszBuf, DW
     return ret;
 }
 #endif
+#ifdef IFS3216_OVERWRITE_IMessageFilter_HandleInComingCall
+DWORD STDMETHODCALLTYPE IMessageFilter_32_16_HandleInComingCall(IMessageFilter *This, DWORD dwCallType,HTASK htaskCaller,DWORD dwTickCount,LPINTERFACEINFO lpInterfaceInfo)
+{
+    SEGPTR iface16 = get_interface16(This);
+    TYP16_DWORD result__ = {0};
+    DWORD result32__ = {0};
+    TYP16_DWORD args16_dwCallType;
+    TYP16_HTASK args16_htaskCaller;
+    TYP16_DWORD args16_dwTickCount;
+    TYP16_LPINTERFACEINFO args16_lpInterfaceInfo;
+    MAP_DWORD32_16(args16_dwCallType, dwCallType);
+    MAP_HTASK32_16(args16_htaskCaller, htaskCaller);
+    MAP_DWORD32_16(args16_dwTickCount, dwTickCount);
+    MAP_LPINTERFACEINFO32_16(args16_lpInterfaceInfo, lpInterfaceInfo);
+    TRACE("(%p(%04x:%04x),%08x,%08x,%08x,%p)\n", This, SELECTOROF(iface16), OFFSETOF(iface16), dwCallType, htaskCaller, dwTickCount, lpInterfaceInfo);
+    result__ = (TYP16_DWORD)IMessageFilter16_HandleInComingCall(iface16, args16_dwCallType, args16_htaskCaller, args16_dwTickCount, args16_lpInterfaceInfo);
+    if (result__ > 2)
+        result__ = 0;
+    MAP_DWORD16_32(result32__, result__);
+    UNMAP_DWORD32_16(args16_dwCallType, dwCallType);
+    UNMAP_HTASK32_16(args16_htaskCaller, htaskCaller);
+    UNMAP_DWORD32_16(args16_dwTickCount, dwTickCount);
+    UNMAP_LPINTERFACEINFO32_16(args16_lpInterfaceInfo, lpInterfaceInfo);
+    return result32__;
+}
+#endif

--- a/ole2/ifs_thunk.h
+++ b/ole2/ifs_thunk.h
@@ -225,16 +225,21 @@ ULONG WINAPI ISTGMEDIUMRelease_32_16_Release(ISTGMEDIUMRelease *iface);
 #define UNMAP_IID_PTR32_16
 #define UNMAP_REFCLSID32_16
 #define UNMAP_REFCLSID16_32
-#define UNMAP_PTR_FORMATETC32_16
-#define UNMAP_PTR_FORMATETC16_32
+#define UNMAP_PTR_FORMATETC32_16(a16, a32) \
+	if (((FORMATETC16 *)MapSL(a16))->ptd) { \
+		HeapFree(GetProcessHeap(), 0, MapSL(((FORMATETC16 *)MapSL(a16))->ptd)); \
+		UnMapLS(((FORMATETC16 *)MapSL(a16))->ptd); \
+		UnMapLS(a16); \
+	}
+#define UNMAP_PTR_FORMATETC16_32(a32, a16) if (a32->ptd) HeapFree(GetProcessHeap(), 0, a32->ptd);
 #define UNMAP_STGMEDIUM32_16
 #define UNMAP_STGMEDIUM16_32
 #define UNMAP_LPINTERFACEINFO32_16
 #define UNMAP_LPINTERFACEINFO16_32
 #define UNMAP_PTR_STGMEDIUM32_16
 #define UNMAP_PTR_STGMEDIUM16_32
-#define MAP_PTR_FORMATETC16_32(a32, a16) map_formatetc16_32(a32 = (FORMATETC*)alloca(sizeof(FORMATETC)), (FORMATETC16*)MapSL(a16))
-#define MAP_PTR_FORMATETC32_16(a16, a32) map_formatetc32_16((FORMATETC16*)MapSL(a16 = MapLS(alloca(sizeof(FORMATETC16)))), a32);
+#define MAP_PTR_FORMATETC16_32(a32, a16) map_pformatetc16_32(a32 = (FORMATETC*)alloca(sizeof(FORMATETC)), (FORMATETC16*)MapSL(a16))
+#define MAP_PTR_FORMATETC32_16(a16, a32) map_pformatetc32_16((FORMATETC16*)MapSL(a16 = MapLS(alloca(sizeof(FORMATETC16)))), a32);
 
 #define MAP_PTR_STGMEDIUM16_32(a32, a16) map_stgmedium16_32(a32 = (STGMEDIUM*)alloca(sizeof(STGMEDIUM)), (STGMEDIUM16*)MapSL(a16))
 

--- a/ole2/ifs_thunk.h
+++ b/ole2/ifs_thunk.h
@@ -1063,4 +1063,8 @@ HRESULT CDECL ITypeInfo_16_32_Invoke(SEGPTR This, SEGPTR args16_pvInstance, DWOR
 
 #define IFS1632_OVERWRITE_ITypeLib_FindName
 HRESULT CDECL ITypeLib_16_32_FindName(SEGPTR This, SEGPTR args16_szNameBuf, DWORD args16_lHashVal, SEGPTR args16_ppTInfo, SEGPTR args16_rgMemId, SEGPTR args16_pcFound);
+
+#define IFS3216_OVERWRITE_IMessageFilter_HandleInComingCall
+DWORD STDMETHODCALLTYPE IMessageFilter_32_16_HandleInComingCall(IMessageFilter *This, DWORD dwCallType,HTASK htaskCaller,DWORD dwTickCount,LPINTERFACEINFO lpInterfaceInfo);
+
 #endif


### PR DESCRIPTION
fixes equation editor (https://github.com/otya128/winevdm/issues/934), ntvdm appears to work this way too