### PR TITLE
use null_pen stock object for ps_null pen

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -1888,6 +1888,9 @@ HPEN16 WINAPI CreatePen16( INT16 style, INT16 width, COLORREF color )
 {
     LOGPEN logpen;
 
+    if (style == PS_NULL)
+        return GetStockObject16(NULL_PEN);
+
     logpen.lopnStyle = style;
     logpen.lopnWidth.x = width;
     logpen.lopnWidth.y = 0;
@@ -1903,6 +1906,9 @@ HPEN16 WINAPI CreatePenIndirect16( const LOGPEN16 * pen )
 {
     LOGPEN logpen;
 
+    if (pen->lopnStyle == PS_NULL)
+        return GetStockObject16(NULL_PEN);
+    
     if (pen->lopnStyle > PS_INSIDEFRAME) return 0;
     logpen.lopnStyle   = pen->lopnStyle;
     logpen.lopnWidth.x = pen->lopnWidth.x;


### PR DESCRIPTION
This appears to fix ms graph without requiring https://github.com/otya128/winevdm/commit/ab9c3cc7e5b087d02932bdf7931410fdaf9eebd9