### PR TITLE
globalalloc(gptr) returns a selector so don't bother locking it

### DIFF
--- a/ole2disp/ole2disp.c
+++ b/ole2disp/ole2disp.c
@@ -51,7 +51,7 @@ typedef struct
 static SEGPTR safearray_alloc(ULONG size)
 {
     HANDLE16 h;
-    return WOWGlobalAllocLock16(GPTR, size, &h);
+    return MAKESEGPTR(WOWGlobalAlloc16(GPTR, size), 0);
 }
 
 static void safearray_free(SEGPTR ptr)


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/955 which creates a 0 byte array which causes globallock to fail