### PR TITLE
last entry of accelerator table has bit 7 of fVirt set

### DIFF
--- a/user/user.c
+++ b/user/user.c
@@ -1431,6 +1431,11 @@ HACCEL16 WINAPI LoadAccelerators16(HINSTANCE16 instance, LPCSTR lpTableName)
                 table[i].fVirt = table16[i].fVirt & 0x7f;
                 table[i].key   = table16[i].key;
                 table[i].cmd   = table16[i].cmd;
+                if (table16[i].fVirt & 0x80)
+                {
+                    count = i + 1;
+                    break;
+                }
             }
             ret = CreateAcceleratorTableA( table, count );
             HeapFree( GetProcessHeap(), 0, table );


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/960
Watcom source documents this (https://github.com/open-watcom/open-watcom-v2/blob/master/bld/wres/h/resaccel.h#L58).   Windows has undocumented behavior (apparently used by ntvdm) that CreateAcceleratorTable will stop processing if that bit is set but I just do it directly to avoid depending on that.