### PR TITLE
treat an invalid rect pointer as empty

### DIFF
--- a/user/user.c
+++ b/user/user.c
@@ -708,7 +708,15 @@ BOOL16 WINAPI CopyRect16( RECT16 *dest, const RECT16 *src )
  */
 BOOL16 WINAPI IsRectEmpty16( const RECT16 *rect )
 {
-    return ((rect->left >= rect->right) || (rect->top >= rect->bottom));
+    __TRY
+    {
+        return ((rect->left >= rect->right) || (rect->top >= rect->bottom));
+    }
+    __EXCEPT_ALL
+    {
+        return TRUE;
+    }
+    __ENDTRY
 }
 
 


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/964