### PR TITLE
pass handle to freelibrary

### DIFF
--- a/ole2/ole2.c
+++ b/ole2/ole2.c
@@ -84,8 +84,8 @@ BOOL WINAPI Ole2_LibMain(DWORD fdwReason, HINSTANCE hinstDLL, WORD ds,
 }
 int WINAPI Ole2_WEP(HINSTANCE16 hInstance, WORD wDataSeg, WORD cbHeapSize, LPSTR lpCmdLine)
 {
-    FreeLibrary16("STORAGE.DLL");
-    FreeLibrary16("COMPOBJ.DLL");
+    FreeLibrary16(GetModuleHandle16("STORAGE"));
+    FreeLibrary16(GetModuleHandle16("COMPOBJ"));
     return TRUE;
 }
 /******************************************************************************


### PR DESCRIPTION
fixes random error with programs like bc45 which load and unload ole2