### PR TITLE
add devicemode and load default devmode in createdc if initdata is null

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -1778,10 +1778,10 @@ HDC16 WINAPI CreateDC16( LPCSTR driver, LPCSTR device, LPCSTR output,
         if (!initData || !IsValidDevmodeA(initData, initData->dmSize + initData->dmDriverExtra))
         {
             LONG size = ExtDeviceMode(NULL, NULL, NULL, device, output, NULL, NULL, 0);
-            char *dma = (char *)malloc(size);
-            ExtDeviceMode(NULL, NULL, dma, device, output, NULL, NULL, DM_COPY);
-            HDC16 ret = HDC_16(CreateDCA(driver, device, output, dma));
-            free(dma);
+            char *dma = (char *)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, size);
+            ExtDeviceMode(NULL, NULL, (LPDEVMODEA)dma, device, output, NULL, NULL, DM_COPY);
+            HDC16 ret = HDC_16(CreateDCA(driver, device, output, (LPDEVMODEA)dma));
+            HeapFree(GetProcessHeap(), 0, (LPVOID)dma);
             return ret;
         }
         else

--- a/winspool/winspool.c
+++ b/winspool/winspool.c
@@ -119,6 +119,7 @@ int WINAPI ExtDeviceMode16(HWND16 hwnd16, HANDLE16 hDriver16, LPDEVMODE16 pDevMo
 }
 void WINAPI DeviceMode16(HWND16 hwnd, HMODULE16 hModule16, LPSTR lpszDevice, LPSTR lpszOutput)
 {
+    ExtDeviceMode16(hwnd, hModule16, NULL, lpszDevice, lpszOutput, NULL, NULL, DM_PROMPT|DM_UPDATE);
     return;
 }
 DWORD WINAPI DeviceCapabilities16(LPCSTR pDevice, LPCSTR pPort, WORD fwCapability, LPSTR pOutput, CONST DEVMODE16 *pDevMode)


### PR DESCRIPTION
windows doesn't load the default devmode so we have to do it
fixes https://github.com/otya128/winevdm/issues/1017