### PR TITLE
disable calling globalpagelock in getvdmpointer

### DIFF
--- a/krnl386/thunk.c
+++ b/krnl386/thunk.c
@@ -2431,7 +2431,7 @@ void WINAPI Throw16( LPCATCHBUF lpbuf, INT16 retval, CONTEXT *context )
  */
 DWORD WINAPI GetVDMPointer32W16( SEGPTR vp, UINT16 fMode )
 {
-    GlobalPageLock16(GlobalHandle16(SELECTOROF(vp)));
+    //GlobalPageLock16(GlobalHandle16(SELECTOROF(vp))); // FIXME: needed for win95 compat?
     return (DWORD)K32WOWGetVDMPointer( vp, 0, (DWORD)fMode );
 }
 


### PR DESCRIPTION
This was added for the encarta 99 installer https://marc.info/?l=wine-patches&m=100844023717798&w=2 https://marc.info/?l=wine-patches&m=100844023717798&w=2 but that appears to work differently in windows nt (and on windows 10 it just bails with success after doing nothing).
Fixes hopefully https://github.com/otya128/winevdm/issues/1023