### PR TITLE
return a handle from winexec even if the task dies too quickly

### DIFF
--- a/krnl386/ne_module.c
+++ b/krnl386/ne_module.c
@@ -1281,7 +1281,7 @@ static HINSTANCE16 NE_CreateThread( NE_MODULE *pModule, WORD cmdShow, LPCSTR cmd
             }
             RestoreThunkLock(count);
             CloseHandle( hThread );
-            return exit_code;
+            return hTask; // return something that looks like an hinstance
         }
         if (!(pTask = GlobalLock16( hTask ))) break;
         instance = pTask->hInstance;


### PR DESCRIPTION
vb3 shell() fails if winexec returns a value that looks like an error.

fixes https://github.com/otya128/winevdm/issues/1043