### PR TITLE
don't try to create a thunk to a null windowproc

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -1628,7 +1628,9 @@ LONG WINAPI GetWindowLong16( HWND16 hwnd16, INT16 offset )
         }
         if (retvalue)
             return retvalue;
-        retvalue = (LONG_PTR)WINPROC_GetProc16( (WNDPROC)GetWindowLongA(hwnd, offset), FALSE );
+        retvalue = GetWindowLongA(hwnd, offset);
+        if (retvalue)
+            retvalue = (LONG_PTR)WINPROC_GetProc16( (WNDPROC)retvalue, FALSE );
         return retvalue;
     }
     if (offset >= 0)


### PR DESCRIPTION
Bcw tries to call the desktop window proc which is in a different process so getwindowlonga returns null.  If the window proc is null, it doesn't try to call it.
fixes https://github.com/otya128/winevdm/issues/1052