### PR TITLE
kill send_message_callback usage

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -2748,52 +2748,6 @@ static LRESULT send_message_timeout_callback( HWND hwnd, UINT msg, WPARAM wp, LP
 
 typedef struct
 {
-    DWORD magic;
-    LRESULT *result;
-    HANDLE event;
-} send_message_callback_args;
-
-void CALLBACK send_message_callback_cb(HWND hwnd, UINT msg, ULONG_PTR param, LRESULT res)
-{
-    send_message_callback_args *args = (send_message_callback_args *)param;
-    if (args->magic != 0xBEEFBEEF)
-        return;
-    *args->result = res;
-    SetEvent(args->event);
-}
-
-static LRESULT send_message_callback_callback( HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
-                                      LRESULT *result, void *arg )
-{
-    send_message_callback_args args;
-    args.result = result;
-    args.event = CreateEventA(NULL, TRUE, FALSE, NULL);
-    args.magic = 0xBEEFBEEF;
-    BOOL ret = SendMessageCallbackA(hwnd, msg, wp, lp, send_message_callback_cb, &args);
-    if (ret)
-    {
-        DWORD count;
-        ReleaseThunkLock(&count);
-        DWORD timeout = GetTickCount() + 1000;
-        do
-        {
-            MSG msg;
-            DWORD ret = MsgWaitForMultipleObjects(1, &args.event, FALSE, timeout - GetTickCount(), QS_ALLINPUT);
-            if (ret != (WAIT_OBJECT_0 + 1))
-                break;
-            PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE);
-        } while(GetTickCount() < timeout);
-        RestoreThunkLock(count);
-    }
-    else if (GetLastError() == ERROR_MESSAGE_SYNC_ONLY)
-        send_message_timeout_callback(hwnd, msg, wp, lp, result, arg);
-    args.magic = 0;
-    CloseHandle(args.event);
-    return TRUE;
-}
-
-typedef struct
-{
     UINT msg;
     WPARAM wp;
     LPARAM lp;
@@ -2915,10 +2869,7 @@ LRESULT WINAPI SendMessage16( HWND16 hwnd16, UINT16 msg, WPARAM16 wparam, LPARAM
                 return result;
         }
         TRACE_(message)("(0x%04x) to 32-bit [%04x] wp=%04x lp=%08lx\n", hwnd16, msg, wparam, lparam);
-        if (pid == GetCurrentProcessId())
-            WINPROC_CallProc16To32A( send_message_callback_callback, hwnd16, msg, wparam, lparam, &result, NULL );
-        else
-            WINPROC_CallProc16To32A( send_message_timeout_callback, hwnd16, msg, wparam, lparam, &result, NULL );
+        WINPROC_CallProc16To32A( send_message_timeout_callback, hwnd16, msg, wparam, lparam, &result, NULL );
         TRACE_(message)("(0x%04x) to 32-bit [%04x] wp=%04x lp=%08lx returned %08lx\n",
             hwnd16, msg, wparam, lparam, result);
     }


### PR DESCRIPTION
Isn't needed anymore for wordperfect and causes problems with loading in iphotoplus (https://github.com/otya128/winevdm/issues/1058)