### PR TITLE
don't call createfile in openfile if of_parse is set and unrevert ret…

### DIFF
--- a/krnl386/file.c
+++ b/krnl386/file.c
@@ -799,7 +799,7 @@ HFILE16 WINAPI OpenFile16( LPCSTR name, OFSTRUCT *ofs, UINT16 mode )
             handle = INVALID_HANDLE_VALUE;
             hFileRet = HFILE_ERROR16;
         }
-        else
+        else if (!(mode & OF_PARSE))
         {
             handle = create_file_OF(pathname, mode);
         }

--- a/ole2/ole2.c
+++ b/ole2/ole2.c
@@ -116,16 +116,17 @@ HRESULT WINAPI OleInitialize16(SEGPTR pMalloc)
 /******************************************************************************
  *		OleUninitialize	(OLE2.3)
  */
-void WINAPI OleUninitialize16(void)
+HRESULT WINAPI OleUninitialize16(void)
 {
     HMODULE comp = GetModuleHandleA("compobj.dll16");
+    HRESULT ret;
     if (!comp)
     {
         comp = LoadLibraryA("compobj.dll16");
     }
     ((void(WINAPI*)())GetProcAddress(comp, "CoUninitialize16"))();
     OleUninitialize();
-    return;
+    return 0;
 }
 
 /***********************************************************************


### PR DESCRIPTION
…urning 0 in OleUninitialize

fixes https://github.com/otya128/winevdm/issues/1060
also fixes msaccess setup which fails if oleuninitialize returns nonzero (https://github.com/otya128/winevdm/pull/854)