### PR TITLE
make hdc cache unconditional, check for null in sndplaysound, fix rle…

### DIFF
--- a/mmsystem/mmsystem.c
+++ b/mmsystem/mmsystem.c
@@ -319,7 +319,7 @@ BOOL16 WINAPI sndPlaySound16(LPCSTR lpszSoundName, UINT16 uFlags)
     BOOL16	retv;
     DWORD	lc;
     char	buf[36];
-    if ((uFlags & SND_MEMORY) && (*(DWORD *)(lpszSoundName + 4) < 36))
+    if (lpszSoundName && (uFlags & SND_MEMORY) && (*(DWORD *)(lpszSoundName + 4) < 36))
     {
         memset(buf, 0, 36);
         memcpy(buf, lpszSoundName, *(DWORD *)(lpszSoundName + 4));

--- a/user/window.c
+++ b/user/window.c
@@ -1172,28 +1172,19 @@ INT16 WINAPI ReleaseDC16( HWND16 hwnd, HDC16 hdc )
         hwnd = HWND_16(GetDesktopWindow());
     if (WindowFromDC(HDC_32(hdc)) != HWND_32(hwnd))
         return 0;
-    if (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a)
+    if (dcc.dcs[dcc.next])
     {
-        if (dcc.dcs[dcc.next])
+        HDC16 oldhdc = dcc.dcs[dcc.next];
+        HDC16 oldhwnd = dcc.wnds[dcc.next];
+        if(ReleaseDC( WIN_Handle32(oldhwnd), HDC_32(oldhdc) ) || !IsWindow(HWND_32(oldhwnd)))
         {
-            HDC16 oldhdc = dcc.dcs[dcc.next];
-            HDC16 oldhwnd = dcc.wnds[dcc.next];
-            if(ReleaseDC( WIN_Handle32(oldhwnd), HDC_32(oldhdc) ) || !IsWindow(HWND_32(oldhwnd)))
-            {
-                K32WOWHandle16DestroyHint(HDC_32(oldhdc), WOW_TYPE_HDC);
-            }
+            K32WOWHandle16DestroyHint(HDC_32(oldhdc), WOW_TYPE_HDC);
         }
-        dcc.dcs[dcc.next] = hdc;
-        dcc.wnds[dcc.next] = hwnd;
-        dcc.next = (dcc.next + 1) % 5;
-        return 1;
     }
-    INT16 result = (INT16)ReleaseDC( WIN_Handle32(hwnd), HDC_32(hdc) );
-    if (result)
-    {
-        K32WOWHandle16DestroyHint(HDC_32(hdc), WOW_TYPE_HDC);
-    }
-    return result;
+    dcc.dcs[dcc.next] = hdc;
+    dcc.wnds[dcc.next] = hwnd;
+    dcc.next = (dcc.next + 1) % 5;
+    return 1;
 }
 
 


### PR DESCRIPTION
… size in (stretch|set)dibits

fixes https://github.com/otya128/winevdm/issues/1068

It's a win31 program but uses an hdc after release so the kb doc that says that this was fixed for win31 programs must be wrong.