### PR TITLE
krnl386.exe: Make CallProcEx32W16 clear CPEX_DEST_CDECL flag before l…

### DIFF
--- a/krnl386/thunk.c
+++ b/krnl386/thunk.c
@@ -2556,11 +2556,12 @@ DWORD WINAPIV CallProc32W16( DWORD nrofargs, DWORD argconvmask, FARPROC proc32, 
 DWORD WINAPIV CallProcEx32W16( DWORD nrofargs, DWORD argconvmask, FARPROC proc32, VA_LIST16 valist )
 {
     DWORD args[32];
-    unsigned int i;
+    unsigned int i, count = min( 32, nrofargs & ~CPEX_DEST_CDECL );
 
-    TRACE("(%d,%d,%p args[",nrofargs,argconvmask,proc32);
+    TRACE("(%s,%d,%d,%p args[", nrofargs & CPEX_DEST_CDECL ? "cdecl": "stdcall",
+          nrofargs & ~CPEX_DEST_CDECL, argconvmask, proc32);
 
-    for (i=0;i<nrofargs;i++)
+    for (i = 0; i < count; i++)
     {
         if (argconvmask & (1<<i))
         {


### PR DESCRIPTION
…ooping over arguments.

Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=48480
Signed-off-by: Dirk Niggemann <dirk.niggemann@gmail.com>
Signed-off-by: Alexandre Julliard <julliard@winehq.org>

(https://github.com/otya128/winevdm/issues/1070)