### PR TITLE
prefer handle reuse by same type

### DIFF
--- a/krnl386/wow_handle.c
+++ b/krnl386/wow_handle.c
@@ -118,6 +118,7 @@ WORD get_handle16_data(HANDLE h, HANDLE_STORAGE *hs, HANDLE_DATA **o)
 		return h;
 	}
 	WORD fhandle = 0;
+    DWORD type = GetObjectType(h) << 16;
 
     WORD s = HANDLE_RESERVED;
 retry:
@@ -127,7 +128,7 @@ retry:
             break;
         if (hs->align2 && (i & -hs->align2) == i)
             continue;
-		if (!hs->handles[i].handle32 && !fhandle)
+		if ((!hs->handles[i].handle32 || (hs->handles[i].handle32 == type)) && !fhandle)
 		{
 			fhandle = i;
 		}
@@ -161,7 +162,9 @@ void destroy_handle16(HANDLE_STORAGE *hs, WORD h)
     {
         return;
     }
+    DWORD type = GetObjectType(hs->handles[h].handle32) << 16;
     memset(hs->handles + h, 0, sizeof(*hs->handles));
+    hs->handles[h].handle32 = type;
 }
 BOOL get_handle32_data(WORD h, HANDLE_STORAGE *hs, HANDLE_DATA **o)
 {

--- a/krnl386/wow_handle.c
+++ b/krnl386/wow_handle.c
@@ -77,6 +77,14 @@ void init_wow_handle()
     handle_list[HANDLE_TYPE_HGDI].clean_up = hgdi_clean_up;
 }
 WORD get_handle16_data(HANDLE h, HANDLE_STORAGE *hs, HANDLE_DATA **o);
+
+static DWORD get_handle_type(HANDLE h, HANDLE_STORAGE *hs)
+{
+    if (hs != &handle_list[HANDLE_TYPE_HGDI])
+        return 0;
+    return GetObjectType(h) << 16;
+}
+
 BOOL is_reserved_handle32(HANDLE h)
 {
     SSIZE_T signedh = (SSIZE_T)h;
@@ -118,7 +126,7 @@ WORD get_handle16_data(HANDLE h, HANDLE_STORAGE *hs, HANDLE_DATA **o)
 		return h;
 	}
 	WORD fhandle = 0;
-    DWORD type = GetObjectType(h) << 16;
+    DWORD type = get_handle_type(h, hs);
 
     WORD s = HANDLE_RESERVED;
 retry:
@@ -162,7 +170,7 @@ void destroy_handle16(HANDLE_STORAGE *hs, WORD h)
     {
         return;
     }
-    DWORD type = GetObjectType(hs->handles[h].handle32) << 16;
+    DWORD type = get_handle_type(hs->handles[h].handle32, hs);
     memset(hs->handles + h, 0, sizeof(*hs->handles));
     hs->handles[h].handle32 = type;
 }


### PR DESCRIPTION
https://github.com/otya128/winevdm/issues/704 black dialogs returned with https://github.com/otya128/winevdm/pull/1069.  Make it so when reusing handles the same type is preferred but cleanup clears it out.  I tried having it use the low 16 bits of the win32 handle if it's available in the table to be a bit more similar to how ntvdm in windows xp works but windows 10 appears to break that.