### PR TITLE
put the real windows/system directory at the end of the search path

### DIFF
--- a/krnl386/file.c
+++ b/krnl386/file.c
@@ -460,7 +460,7 @@ BOOL16 WINAPI WriteProfileString16( LPCSTR section, LPCSTR entry,
 /* get the search path for the current module; helper for OpenFile16 */
 /*static */char *get_search_path(void)
 {
-    UINT len;
+    UINT len, i;
     char *ret, *p, module[OFS_MAXPATHNAME];
 
     module[0] = 0;
@@ -471,6 +471,7 @@ BOOL16 WINAPI WriteProfileString16( LPCSTR section, LPCSTR entry,
     }
     char windir[MAX_PATH];
     char windir2[MAX_PATH];
+    char realwinsys[MAX_PATH];
     char *windir3;
     GetWindowsDirectoryA(windir, MAX_PATH);
     windir3 = RedirectSystemDir(windir, windir2, MAX_PATH);
@@ -478,12 +479,15 @@ BOOL16 WINAPI WriteProfileString16( LPCSTR section, LPCSTR entry,
     GetModuleFileNameA(GetModuleHandleA(NULL), vdmpath, MAX_PATH);
     PathRemoveFileSpecA(vdmpath);
     GetShortPathNameA(vdmpath, vdmpath, MAX_PATH);
+    strcpy(realwinsys, windir);
+    strcat(realwinsys, "\\SYSTEM");
 
     len = (strlen(vdmpath) + 1 + 2 +                                              /* search order: first current dir */
            GetSystemDirectory16( NULL, 0 ) + 1 +            /* then system dir */
            strlen(windir3) + 1 +            /* then windows dir */
            strlen( module ) + 1 +                           /* then module path */
-           GetEnvironmentVariableA( "PATH16", NULL, 0 ) + 1); /* then look in PATH */
+           GetEnvironmentVariableA( "PATH16", NULL, 0 ) + 1 + /* then look in PATH */
+           strlen(realwinsys) + 1); /* then the real windows system dir */
     if (!(ret = HeapAlloc( GetProcessHeap(), 0, len ))) return NULL;
     strcpy(ret, ".;");
     p = ret + 2;
@@ -503,10 +507,13 @@ BOOL16 WINAPI WriteProfileString16( LPCSTR section, LPCSTR entry,
         p += strlen( p );
         *p++ = ';';
     }
-    if (!GetEnvironmentVariableA("PATH16", p, ret + len - p))
+    i = GetEnvironmentVariableA("PATH16", p, ret + len - p);
+    if (i)
     {
-        *(p - 1) = '\0';
+        p += i;
+        *p++ = ';';
     }
+    strcpy(p, realwinsys);
     return ret;
 }
 char *krnl386_get_search_path(void)


### PR DESCRIPTION
32bit installers will place 16bit dlls into the real windows/system dir (https://github.com/otya128/winevdm/issues/1070)