### PR TITLE
only force swp_framechanged if the size if changing

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -2079,9 +2079,9 @@ BOOL16 WINAPI SetWindowPos16( HWND16 hwnd, HWND16 hwndInsertAfter,
     }
     if (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a)
     {
-	    if (flags & SWP_NOREDRAW)
+        RECT rect;
+        if (flags & SWP_NOREDRAW)
         {
-            RECT rect;
             GetWindowRect(hwnd32, &rect);
             /* top-level window */
             if (GetAncestor(hwnd32, GA_PARENT) == GetDesktopWindow())
@@ -2094,7 +2094,11 @@ BOOL16 WINAPI SetWindowPos16( HWND16 hwnd, HWND16 hwndInsertAfter,
             }
         }
         if (!(flags & SWP_NOMOVE))
-    	    flags |= SWP_FRAMECHANGED; // force WM_NCCALCSIZE
+        {
+            GetClientRect(hwnd32, &rect);
+            if ((cx != rect.right) || (cy != rect.bottom))
+                flags |= SWP_FRAMECHANGED; // force WM_NCCALCSIZE
+        }
     }
     DWORD count;
     ReleaseThunkLock(&count);


### PR DESCRIPTION
fixes paint in https://github.com/otya128/winevdm/issues/1087

Windows has GACF_NCCALCSIZEONMOVE (https://jeffpar.github.io/kbarchive/kb/082/Q82860/) which is a compat layer so although this change works for both Castle of the Winds (https://github.com/otya128/winevdm/issues/988) and mviewer there may be no solution that works for everything.