### PR TITLE
use richedit outline mode for contents file

### DIFF
--- a/winhlp32/hlpfile.c
+++ b/winhlp32/hlpfile.c
@@ -3033,7 +3033,7 @@ static void HLPFILE_ReadCntFile(HLPFILE *hlpfile)
     rd.ptr = rd.data = HeapAlloc(GetProcessHeap(), 0, 1024);
     rd.allocated = 1024;
     cnt = (HLPFILE_PAGE *)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(HLPFILE_PAGE));
-    if (!HLPFILE_RtfAddControl(&rd, "{\\rtf1\\ansi\\urtf0\\deff0{\\fonttbl{\\f0\\fcharset0 Times New Roman;}}", tmp)) goto errexit;
+    if (!HLPFILE_RtfAddControl(&rd, "{\\rtf1\\ansi\\urtf0\\deff0{\\fonttbl{\\f0\\fcharset0 Times New Roman;}}")) goto errexit;
     if (!HLPFILE_RtfAddControl(&rd, "{\\stylesheet{ Normal;}{\\s1 heading 1;}{\\s2 heading 2;}{\\s3 heading 3;}{\\s4 heading 4;}{\\s5 heading 5;}{\\s6 heading 6;}{\\s7 heading 7;}{\\s8 heading 8;}{\\s9 heading 9;}}")) goto errexit;
     if (!HLPFILE_RtfAddControl(&rd, "\\viewkind2")) goto errexit;
     str = buf;

--- a/winhlp32/hlpfile.c
+++ b/winhlp32/hlpfile.c
@@ -3001,7 +3001,7 @@ static void HLPFILE_ReadCntFile(HLPFILE *hlpfile)
     struct RtfData rd = {0};
     HANDLE h;
     char tmp[256];
-    WCHAR tmpW[512];
+    WCHAR tmpW[256];
     HLPFILE_PAGE *cnt;
 
     rd.in_text = TRUE;
@@ -3114,8 +3114,8 @@ static void HLPFILE_ReadCntFile(HLPFILE *hlpfile)
         }
         else curl++;
         // outline only works with utf8 codepage
-        MultiByteToWideChar(hlpfile->codepage, 0, start, -1, tmpW, 512);
-        tmpW[511] = 0;
+        MultiByteToWideChar(hlpfile->codepage, 0, start, -1, tmpW, 256);
+        tmpW[255] = 0;
         WideCharToMultiByte(CP_UTF8, 0, tmpW, -1, tmp, 256, NULL, NULL);
         tmp[255] = 0;
         if (!HLPFILE_RtfAddControl(&rd, tmp)) goto errexit;

--- a/winhlp32/hlpfile.c
+++ b/winhlp32/hlpfile.c
@@ -3039,7 +3039,7 @@ static void HLPFILE_ReadCntFile(HLPFILE *hlpfile)
     str = buf;
     while (str)
     {
-        char *start, *end;
+        unsigned char *start, *end;
 
         next_str = strchr(str, '\n');
         if (next_str)
@@ -3130,10 +3130,7 @@ static void HLPFILE_ReadCntFile(HLPFILE *hlpfile)
     cnt->first_link = rd.first_link;
     cnt->offset = rd.ptr - rd.data;
     if (!cnt->lpszTitle) 
-    {
-        const WCHAR deftitle[] = {'C', 'o', 'n', 't', 'e', 'n', 't', 's', 0};
-        cnt->lpszTitle = deftitle;
-    }
+        cnt->lpszTitle = (WCHAR*)L"Contents";
     HeapFree(GetProcessHeap(), 0, buf);
     return;
 errexit:

--- a/winhlp32/hlpfile.h
+++ b/winhlp32/hlpfile.h
@@ -113,6 +113,7 @@ typedef struct tagHlpFileFile
     LPSTR                       lpszPath;
     LPSTR                       lpszTitle;
     LPSTR                       lpszCopyright;
+    LPSTR			lpszCntPath;
     HLPFILE_PAGE*               first_page;
     HLPFILE_PAGE*               last_page;
     HLPFILE_MACRO*              first_macro;
@@ -126,6 +127,9 @@ typedef struct tagHlpFileFile
     BYTE*                       ttlbtree;
     BYTE*                       rose;
     BYTE*                       viola;
+
+    BYTE*			cnt_rtf;
+    HLPFILE_PAGE*               cnt_page;
 
     struct tagHlpFileFile*      prev;
     struct tagHlpFileFile*      next;

--- a/winhlp32/hlpfile.h
+++ b/winhlp32/hlpfile.h
@@ -113,7 +113,7 @@ typedef struct tagHlpFileFile
     LPSTR                       lpszPath;
     LPSTR                       lpszTitle;
     LPSTR                       lpszCopyright;
-    LPSTR			lpszCntPath;
+    LPSTR                       lpszCntPath;
     HLPFILE_PAGE*               first_page;
     HLPFILE_PAGE*               last_page;
     HLPFILE_MACRO*              first_macro;
@@ -128,7 +128,7 @@ typedef struct tagHlpFileFile
     BYTE*                       rose;
     BYTE*                       viola;
 
-    BYTE*			cnt_rtf;
+    BYTE*                       cnt_rtf;
     HLPFILE_PAGE*               cnt_page;
 
     struct tagHlpFileFile*      prev;


### PR DESCRIPTION
Two issues, when the background isn't white the expand icons disappear and when an top level outline is expanded, all the children are too.