### PR TITLE
dib palette handling

### DIFF
--- a/otvdm.ini
+++ b/otvdm.ini
@@ -104,6 +104,9 @@
 ; in a tight loop using all the available cpu time, wait time in milliseconds (default: 0)
 ;PeekMessageSleep=5
 
+; Emulate 8bpp color mode using DIBs (default: 0)
+;DIBPalette=0
+
 ; If EnumFontLimitation=1, this section declare the font to be enumerated.
 ;[EnumFontLimitation]
 ;font name=1(enumerated)/0(not enumerated)

--- a/user/user.def
+++ b/user/user.def
@@ -13,4 +13,5 @@ EXPORTS
   window_message16_32
   window_message32_16
   LoadString16
-
+  set_realized_palette
+  get_realized_palette

--- a/user/user.exe16.spec
+++ b/user/user.exe16.spec
@@ -595,3 +595,5 @@
 @ stdcall -arch=win32 window_message16_32(ptr ptr)
 @ stdcall -arch=win32 window_message32_16(ptr ptr)
 @ stdcall -arch=win32 LoadString16(long long ptr long)
+@ stdcall -arch=win32 set_realized_palette(long)
+@ stdcall -arch=win32 get_realized_palette()


### PR DESCRIPTION
This uses dibs to emulate 256 color mode as an optional alternative to faking it as the current compat mode does.  It improves colors in things like Magic School Bus Explores the Human Body (https://github.com/otya128/winevdm/issues/759), Pirates (https://github.com/otya128/winevdm/issues/638) and Yellow Brick Road II.  It's not the default though because things which use DIBs internally like Fields of Battle (https://github.com/otya128/winevdm/issues/150) and Keroppi Day Hopper are worse.  Other things like the rest of Big Top (https://github.com/otya128/winevdm/issues/223) and The Incredible Machine (https://github.com/otya128/winevdm/issues/75) don't display any differently.