### PR TITLE
delete file if int21 3c is called for an existing file.

### DIFF
--- a/krnl386/int21.c
+++ b/krnl386/int21.c
@@ -1134,6 +1134,9 @@ static BOOL INT21_CreateFile( CONTEXT *context,
     retry:
     MultiByteToWideChar(CP_OEMCP, 0, pathA, -1, pathW, MAX_PATH);
 
+    if (dosAction == 0x12)
+        DeleteFileW(pathW);
+
     if ((winHandle = INT21_OpenMagicDevice( pathW, winAccess )))
     {
         dosStatus = 1;


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1104 where it tries to truncate a hidden file.  Createfile returns access denied unless the create attributes are the same as the existing file.