### PR TITLE
check for null in ddecreatestringhandle and cbeck for empty dmdevicen…

### DIFF
--- a/ddeml/ddeml.c
+++ b/ddeml/ddeml.c
@@ -417,7 +417,7 @@ HSZ WINAPI DdeCreateStringHandle16(DWORD idInst, LPCSTR str, INT16 codepage)
             return DMLERR_INVALIDPARAMETER;
         }
     }
-    if (!stricmp(str, "Progman"))
+    if (str && !stricmp(str, "Progman"))
         str = "Progman16";
   
     return DdeCreateStringHandleA(idInst, str, CP_WINANSI);

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -3722,6 +3722,7 @@ HDC16 WINAPI ResetDC16( HDC16 hdc, const DEVMODEA *devmode )
     memcpy(&dma, devmode, devmode->dmSize);
     dma.dmSize = sizeof(DEVMODEA);
     dma.dmDriverExtra = 0;
+    if (!dma.dmDeviceName[0]) dma.dmDeviceName[0] = '.';
     return HDC_16( ResetDCA( HDC_32(hdc), &dma ) );
 }
 


### PR DESCRIPTION
…ame in resetdc

fixes https://github.com/otya128/winevdm/issues/1109

Resetdca back to at least xp don't use the devmode if dmdevicename is empty.   It's not a problem with winevdm because the same thing happens in xp/ntvdm but it works fine in that case while Windows 10 crashes so fill in the byte.  There doesn't seem to be a way to get the device name from the device context to put there.  