### PR TITLE
fix local heap corruption and crash in ole2

### DIFF
--- a/krnl386/local.c
+++ b/krnl386/local.c
@@ -1424,6 +1424,7 @@ HLOCAL16 WINAPI LocalReAlloc16( HLOCAL16 handle, WORD size, UINT16 flags )
 
     hmem = LOCAL_GetBlock( ds, size, flags );
     ptr = MapSL( MAKESEGPTR( ds, 0 ));  /* Reload ptr                             */
+    pEntry = (LOCALHANDLEENTRY *)(ptr + handle);
     if(HANDLE_MOVEABLE(handle))         /* LOCAL_GetBlock might have triggered    */
     {                                   /* a compaction, which might in turn have */
       blockhandle = pEntry->addr - MOVEABLE_PREFIX; /* moved the very block we are resizing */

--- a/ole2/ifs_thunk.c
+++ b/ole2/ifs_thunk.c
@@ -850,7 +850,7 @@ void map_bstr16_32(BSTR *a32, const SEGPTR *a16)
     MultiByteToWideChar(CP_ACP, 0, MapSL(*a16), len16 + 1, *a32, len32 + 1);
 }
 
-static int dynamic_SysAllocStringLen16(const char *oleStr, int len);
+static int dynamic_SysAllocStringLen16(SEGPTR bstr, int len);
 void map_bstr32_16(SEGPTR *a16, const BSTR *a32)
 {
     UINT len;
@@ -1967,16 +1967,16 @@ static int dynamic_SysStringLen16(SEGPTR bstr)
     return pSysStringLen16(bstr);
 }
 
-static int dynamic_SysAllocStringLen16(const char *oleStr, int len)
+static int dynamic_SysAllocStringLen16(SEGPTR bstr, int len)
 {
-    static int (WINAPI*pSysAllocStringLen16)(const char *oleStr, int len);
+    static int (WINAPI*pSysAllocStringLen16)(SEGPTR bstr, int len);
     if (!pSysAllocStringLen16)
     {
         pSysAllocStringLen16 = GetProcAddress(get_hmodule_helper("OLE2DISP.DLL16"), "SysAllocStringLen16");
     }
     if (!pSysAllocStringLen16)
         return 0;
-    return pSysAllocStringLen16(oleStr, len);
+    return pSysAllocStringLen16(bstr, len);
 }
 
 void free_excepinfo16(const EXCEPINFO16 *a16)

--- a/ole2disp/ole2disp.dll16.spec
+++ b/ole2disp/ole2disp.dll16.spec
@@ -1,8 +1,8 @@
 1 stub DLLGETCLASSOBJECT
 2 pascal SysAllocString(str)		SysAllocString16
 3 pascal SysReallocString(ptr str)	SysReAllocString16
-4 pascal SysAllocStringLen(str word)	SysAllocStringLen16
-5 pascal SysReAllocStringLen(ptr str word) SysReAllocStringLen16
+4 pascal SysAllocStringLen(segstr word)	SysAllocStringLen16
+5 pascal SysReAllocStringLen(ptr segstr word) SysReAllocStringLen16
 6 pascal SysFreeString(segstr)		SysFreeString16
 7 pascal SysStringLen(segstr)		SysStringLen16
 8 pascal VariantInit(ptr) VariantInit16

--- a/ole2disp/ole2disp.h
+++ b/ole2disp/ole2disp.h
@@ -130,7 +130,7 @@ HRESULT WINAPI SafeArrayDestroyData16(SAFEARRAY16 *sa);
 HRESULT WINAPI SafeArrayCopy16(SAFEARRAY16 *sa, SAFEARRAY16 **ppsaout);
 SEGPTR WINAPI SysAllocString16(LPCOLESTR16 oleStr);
 INT16 WINAPI SysReAllocString16(SEGPTR *pbstr, LPCOLESTR16 oleStr);
-SEGPTR WINAPI SysAllocStringLen16(SEGPTR *oleStr, int len);
+SEGPTR WINAPI SysAllocStringLen16(SEGPTR oleStr, int len);
 int WINAPI SysReAllocStringLen16(SEGPTR *old, SEGPTR in, int len);
 void WINAPI SysFreeString16(SEGPTR str);
 int WINAPI SysStringLen16(SEGPTR str);

--- a/ole2disp/ole2disp.h
+++ b/ole2disp/ole2disp.h
@@ -37,10 +37,10 @@ typedef OLECHAR16 *BSTR16;
 typedef BSTR16 *LPBSTR16;
 
 SEGPTR WINAPI SysAllocString16(LPCOLESTR16);
-SEGPTR WINAPI SysAllocStringLen16(const char*, int);
+SEGPTR WINAPI SysAllocStringLen16(SEGPTR, int);
 VOID   WINAPI SysFreeString16(SEGPTR);
 INT16  WINAPI SysReAllocString16(SEGPTR*,LPCOLESTR16);
-int    WINAPI SysReAllocStringLen16(SEGPTR*, const char*,  int);
+int    WINAPI SysReAllocStringLen16(SEGPTR*, SEGPTR,  int);
 int    WINAPI SysStringLen16(SEGPTR);
 
 typedef struct tagVARIANT16 {
@@ -130,8 +130,8 @@ HRESULT WINAPI SafeArrayDestroyData16(SAFEARRAY16 *sa);
 HRESULT WINAPI SafeArrayCopy16(SAFEARRAY16 *sa, SAFEARRAY16 **ppsaout);
 SEGPTR WINAPI SysAllocString16(LPCOLESTR16 oleStr);
 INT16 WINAPI SysReAllocString16(SEGPTR *pbstr, LPCOLESTR16 oleStr);
-SEGPTR WINAPI SysAllocStringLen16(const char *oleStr, int len);
-int WINAPI SysReAllocStringLen16(SEGPTR *old, const char *in, int len);
+SEGPTR WINAPI SysAllocStringLen16(SEGPTR *oleStr, int len);
+int WINAPI SysReAllocStringLen16(SEGPTR *old, SEGPTR in, int len);
 void WINAPI SysFreeString16(SEGPTR str);
 int WINAPI SysStringLen16(SEGPTR str);
 int WINAPI SysStringByteLen16(SEGPTR str);


### PR DESCRIPTION
fixes probably https://github.com/otya128/winevdm/issues/1127 where there was local heap corruption when the global memory block containing the local heap is resized and moved making pentry invalid.  Also fixed a crash in notebene that was only detectable with gflags heap validation where a global memory block is moved in SysAllocStringLen16 when the block also contains the src string.  SysAllocStringByteLen16 is only used in 32bit code so is unlikely to be affected.