### PR TITLE
treat forward slash as a pathspec and truncate biheight in wing to an…

### DIFF
--- a/krnl386/file.c
+++ b/krnl386/file.c
@@ -1397,7 +1397,7 @@ static void RedirectPrivateProfileStringWindowsDir(LPCSTR filename, LPCSTR outpu
 {
     if (!filename)
         filename = "win.ini";
-    if (PathIsFileSpecA(filename))
+    if (PathIsFileSpecA(filename) && !strchr(filename, '/'))
     {
         PathCombineA(output, GetRedirectWindowsDir(), filename);
     }

--- a/wing/wing.c
+++ b/wing/wing.c
@@ -180,7 +180,7 @@ HBITMAP16 WINAPI WinGCreateBitmap16(HDC16 hdc, BITMAPINFO *bmpi, SEGPTR *bits)
     DWORD oldsize = bmpi->bmiHeader.biSizeImage;
     bmpi->bmiHeader.biSizeImage = 0;
 
-    if ((oldheight >= 32768) && (oldheight < 65536))
+    if (oldheight >= 32768)
         bmpi->bmiHeader.biHeight = (INT16)(oldheight & 0xffff);
 
     TRACE("(%d,%p,%p): create %dx%dx%d bitmap\n", hdc, bmpi, bits,

--- a/wing/wing.c
+++ b/wing/wing.c
@@ -176,6 +176,12 @@ HBITMAP16 WINAPI WinGCreateBitmap16(HDC16 hdc, BITMAPINFO *bmpi, SEGPTR *bits)
 {
     LPVOID bits32;
     HBITMAP hbitmap;
+    LONG oldheight = bmpi->bmiHeader.biHeight;
+    DWORD oldsize = bmpi->bmiHeader.biSizeImage;
+    bmpi->bmiHeader.biSizeImage = 0;
+
+    if ((oldheight >= 32768) && (oldheight < 65536))
+        bmpi->bmiHeader.biHeight = (INT16)(oldheight & 0xffff);
 
     TRACE("(%d,%p,%p): create %dx%dx%d bitmap\n", hdc, bmpi, bits,
           bmpi->bmiHeader.biWidth, bmpi->bmiHeader.biHeight, bmpi->bmiHeader.biPlanes);
@@ -186,6 +192,8 @@ HBITMAP16 WINAPI WinGCreateBitmap16(HDC16 hdc, BITMAPINFO *bmpi, SEGPTR *bits)
         SEGPTR segptr = alloc_segptr_bits( hbitmap, bits32, (bmpi->bmiHeader.biHeight < 0) );
         if (bits) *bits = segptr;
     }
+    bmpi->bmiHeader.biHeight = oldheight;
+    bmpi->bmiHeader.biSizeImage = oldsize;
     return HBITMAP_16(hbitmap);
 }
 


### PR DESCRIPTION
… int16

fixes https://github.com/otya128/winevdm/issues/1137

It uses a forward slash in the path for getprivateprofilestring which causes it to not be able to find it's ini file properly.  It also fails to sign extend to a long it's top down bitmap height so it's a negative short in a long var.  Wing.dll on win31 uses createcompatiblebitmap which takes an int16 for height so there are unlikely to be any compatibility issues (on win95 and ntvdm it uses createdibsection which is the problem here, I can't imagine there are any win16 wing programs that only work on win95).  Amusingly the readme.txt says that it might not work on win95 which would have been trivial for them to fix.