### PR TITLE
convert handle to sel if needed in freeresource, restore all selector…

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -1852,7 +1852,7 @@ HDC16 WINAPI CreateDC16( LPCSTR driver, LPCSTR device, LPCSTR output,
             for (int i = 0; i < chkcolor; i++)
             {
                 if (((WORD *)bmi->bmiColors)[i] != i) break;
-                if (i == (maxcolor - 1))
+                if (i == (chkcolor - 1))
                 {
                     dib_pal_colors_hack.bmi.biWidth = bmi->bmiHeader.biWidth;
                     dib_pal_colors_hack.bmi.biHeight = bmi->bmiHeader.biHeight;

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -1771,6 +1771,19 @@ struct dib_driver *find_dib_driver(WORD selector)
     }
     return NULL;
 }
+
+struct
+{
+    BITMAPINFOHEADER bmi;
+    RGBQUAD colors[16];
+}  dib_pal_colors_hack =
+{
+    {0x28, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+    {{0, 0, 0}, {0, 0, 0x80}, {0, 0x80, 0}, {0, 0x80, 0x80}, {0x80, 0, 0}, {0x80, 0, 0x80},
+     {0x80, 0x80, 0}, {0xc0, 0xc0, 0xc0}, {0x80, 0x80, 0x80}, {0, 0, 0xff}, {0, 0xff, 0},
+     {0, 0xff, 0xff}, {0xff, 0, 0}, {0xff, 0, 0xff}, {0xff, 0xff, 0}, {0xff, 0xff, 0xff}}
+};
+
 /***********************************************************************
  *           CreateDC    (GDI.53)
  */
@@ -1830,7 +1843,28 @@ HDC16 WINAPI CreateDC16( LPCSTR driver, LPCSTR device, LPCSTR output,
             FIXME("Multiple DIB mappings on the same segment are not supported.\n");
             return HDC_16(memdc);
         }
-        offset_bits = offset + bmi->bmiHeader.biSize + bmi->bmiHeader.biClrUsed * sizeof(RGBQUAD);
+        // check for dib_pal_colors hack
+        if (bmi->bmiHeader.biBitCount <= 8) // does dib.drv support direct color modes?
+        {
+            int maxcolor = bmi->bmiHeader.biClrUsed ? bmi->bmiHeader.biClrUsed : 1 << bmi->bmiHeader.biBitCount;
+            offset_bits = offset + bmi->bmiHeader.biSize + maxcolor * sizeof(RGBQUAD);
+            int chkcolor = bmi->bmiHeader.biClrImportant ? bmi->bmiHeader.biClrImportant : maxcolor;
+            for (int i = 0; i < chkcolor; i++)
+            {
+                if (((WORD *)bmi->bmiColors)[i] != i) break;
+                if (i == (maxcolor - 1))
+                {
+                    dib_pal_colors_hack.bmi.biWidth = bmi->bmiHeader.biWidth;
+                    dib_pal_colors_hack.bmi.biHeight = bmi->bmiHeader.biHeight;
+                    dib_pal_colors_hack.bmi.biBitCount = bmi->bmiHeader.biBitCount;
+                    dib_pal_colors_hack.bmi.biClrUsed = min(maxcolor, 16);
+                    bmi = (BITMAPINFO *)&dib_pal_colors_hack;
+                    break;
+                }
+            }
+        }
+        else
+            offset_bits = offset + bmi->bmiHeader.biSize;
 #define DWORD_PADDING(x) (((x) + 3) & -4)
         offset_align = DWORD_PADDING(offset_bits) - offset_bits;
         avail_size = max(0x10000, limit);

--- a/krnl386/global.c
+++ b/krnl386/global.c
@@ -1367,7 +1367,8 @@ void WINAPI DibUnmapGlobalMemory(void *base, DWORD size)
         {
             pArena->dib_avail_size = 0;
             pArena->base = (LPBYTE)heap + ((SIZE_T)pArena->base - (SIZE_T)base);
-            SetSelectorBase(pArena->handle, pArena->base);
+            for (i = 0; i < pArena->selCount; i++)
+                SetSelectorBase(pArena->handle + i * 8, (LPBYTE)pArena->base + i * 0x10000);
         }
     }
 }

--- a/krnl386/resource.c
+++ b/krnl386/resource.c
@@ -1133,6 +1133,7 @@ BOOL16 WINAPI FreeResource16( HGLOBAL16 handle )
     FARPROC16 proc;
     HMODULE16 user;
     NE_MODULE *pModule = NE_GetPtr( FarGetOwner16( handle ) );
+    handle = GlobalHandleToSel16(handle);
 
     TRACE("(%04x)\n", handle );
 


### PR DESCRIPTION
…s in dibunmapglobalmemory and fix colors if indexes are passed to CreateDC("DIB")
fixes https://github.com/otya128/winevdm/issues/1156
Odell uses dib_pal_colors in stretchdibits but passes the same color table to dib.drv.  Dib.drv will use the 16 color default vga instead but only if the color indexes are sequential.  In 1 bit color mode it uses the first two, 0 and 0x80 rather than the 0 and 0xffffff you'd expect.  In 8 bit color mode it uses these 16 followed by 240 full of junk data, i just cut it off instead.