### PR TITLE
if filepos is 0 then 0 size means 0

### DIFF
--- a/krnl386/ne_segment.c
+++ b/krnl386/ne_segment.c
@@ -1057,7 +1057,7 @@ BOOL NE_CreateSegment( NE_MODULE *pModule, int segnum )
     if ( (pSeg->flags & NE_SEGFLAGS_ALLOCATED) && segnum != pModule->ne_autodata )
         return TRUE;    /* all but DGROUP only allocated once */
 
-    minsize = pSeg->minsize ? pSeg->minsize : 0x10000;
+    minsize = pSeg->minsize || !pSeg->filepos ? pSeg->minsize : 0x10000;
 
     minsize += 2;
 

--- a/vm86/mame/emu/cpu/i386/x87ops.c
+++ b/vm86/mame/emu/cpu/i386/x87ops.c
@@ -5207,6 +5207,7 @@ void x87_fsave(UINT8 modrm)
 
 	for (int i = 0; i < 8; ++i)
 		WRITE80(ea + i*10, ST(i));
+	x87_reset();
 
 	CYCLES((m_cr[0] & 1) ? 56 : 67);
 }


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1158

Latter commit fixes crash in autocad lt