### PR TITLE
if a font is loaded attempt to show it in win.ini [fonts] and fix ret…

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -2810,7 +2810,7 @@ BOOL16 WINAPI TrackPopupMenu16( HMENU16 hMenu, UINT16 wFlags, INT16 x, INT16 y,
                                 INT16 nReserved, HWND16 hwnd, const RECT16 *lpRect )
 {
     RECT r;
-    BOOL ret;
+    BOOL ret, err;
     if (lpRect)
     {
         r.left   = lpRect->left;
@@ -2820,6 +2820,7 @@ BOOL16 WINAPI TrackPopupMenu16( HMENU16 hMenu, UINT16 wFlags, INT16 x, INT16 y,
     }
     ret = TrackPopupMenu( HMENU_32(hMenu), wFlags | TPM_RETURNCMD, x, y, nReserved,
                            WIN_Handle32(hwnd), lpRect ? &r : NULL );
+    err = GetLastError() ? FALSE : TRUE;
     if (ret && !(wFlags & TPM_RETURNCMD))
     {
         if (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a)
@@ -2827,7 +2828,7 @@ BOOL16 WINAPI TrackPopupMenu16( HMENU16 hMenu, UINT16 wFlags, INT16 x, INT16 y,
         else
             PostMessage16(hwnd, WM_COMMAND, ret, 0);
     }
-    return ret;
+    return wFlags & TPM_RETURNCMD ? ret : err;
 }
 
 


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1167

Mozart reads the [fonts] section in win.ini to see if it's font is loaded.  Fonts that winevdm loads from it's windows/system aren't in there so this provides something to satisfy it.  EnumFonts always that I've seen always gives the font name as the first part of the name from [fonts] to a partial match is the best really that can be done.  It also checks the return from trackpopupmenu which is 0 if the menu is canceled with TPM_RETURNCMD but 0 is an error without.  Checking getlasterror should tell whether an error occurred or not.