### PR TITLE
release the lock in defmdichildproc and don't process sent messages o…

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -3293,7 +3293,7 @@ BOOL16 WINAPI GetMessage32_16( MSG32_16 *msg16, HWND16 hwnd16, UINT16 first,
     DWORD count;
 
     /* Do not yield when there is a posted message */
-    if (!PeekMessageA(&msg, hwnd, first, last, PM_REMOVE | PM_QS_POSTMESSAGE | PM_QS_PAINT | PM_QS_INPUT))
+    if (!PeekMessageA(&msg, hwnd, first, last, PM_REMOVE))
     {
         ReleaseThunkLock(&count);
         GetMessageA(&msg, hwnd, first, last);

--- a/user/message.c
+++ b/user/message.c
@@ -3291,8 +3291,8 @@ BOOL16 WINAPI GetMessage32_16( MSG32_16 *msg16, HWND16 hwnd16, UINT16 first,
 
     DWORD count;
 
-    /* Do not yield when there is no message */
-    if (!PeekMessageA(&msg, hwnd, first, last, PM_REMOVE))
+    /* Do not yield when there is a posted message */
+    if (!PeekMessageA(&msg, hwnd, first, last, PM_REMOVE | PM_QS_POSTMESSAGE | PM_QS_PAINT | PM_QS_INPUT))
     {
         ReleaseThunkLock(&count);
         GetMessageA(&msg, hwnd, first, last);

--- a/user/message.c
+++ b/user/message.c
@@ -3184,7 +3184,8 @@ static BOOL CALLBACK enum_scrollbar_proc(HWND hwnd, LPARAM lp)
 static LRESULT defwindow_proc_callback(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp,
     LRESULT *result, void *arg)
 {
-    _LeaveWin16Lock();
+    DWORD count;
+    ReleaseThunkLock(&count);
     if (msg == WM_MOUSEWHEEL)
     {
         enum_scrollbar_data d = { 0 };
@@ -3195,12 +3196,12 @@ static LRESULT defwindow_proc_callback(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp
         {
             SendMessage16(HWND_16(hwnd), WM_VSCROLL, d.down ? SB_LINEDOWN : SB_LINEUP, MAKELONG(0, (WORD)HWND_16(d.hwnd)));
             SendMessage16(HWND_16(hwnd), WM_VSCROLL, SB_ENDSCROLL, MAKELONG(0, (WORD)HWND_16(d.hwnd)));
-            _EnterWin16Lock();
+            RestoreThunkLock(count);
             return 0;
         }
     }
     *result = DefWindowProcA(hwnd, msg, wp, lp);
-    _EnterWin16Lock();
+    RestoreThunkLock(count);
     return *result;
 }
 /***********************************************************************


### PR DESCRIPTION
…utside the lock


~~Sent messages are supposed to be processed first so the getmessage change is not great but I'm not sure how else this can be done.~~ I haven't found problems with this but it can wait.  The defwindowproc change is needed to prevent a deadlock in the neuron netscape plugin.
