### PR TITLE
allocate module segments sequentially

### DIFF
--- a/krnl386/dosmem.c
+++ b/krnl386/dosmem.c
@@ -437,11 +437,11 @@ BOOL DOSMEM_Init(void)
 
     vectored_handler = AddVectoredExceptionHandler(FALSE, dosmem_handler);
     DOSMEM_0000H = GLOBAL_CreateBlock( GMEM_FIXED, DOSMEM_sysmem,
-                                       DOSMEM_64KB, 0, WINE_LDT_FLAGS_DATA );
+                                       DOSMEM_64KB, 0, WINE_LDT_FLAGS_DATA, 0 );
     DOSMEM_BiosDataSeg = GLOBAL_CreateBlock( GMEM_FIXED, DOSMEM_sysmem + 0x400,
-                                             0x100, 0, WINE_LDT_FLAGS_DATA );
+                                             0x100, 0, WINE_LDT_FLAGS_DATA, 0 );
     DOSMEM_BiosSysSeg = GLOBAL_CreateBlock( GMEM_FIXED, DOSMEM_dosmem + 0xf0000,
-                                            DOSMEM_64KB, 0, WINE_LDT_FLAGS_DATA );
+                                            DOSMEM_64KB, 0, WINE_LDT_FLAGS_DATA, 0 );
 
     return TRUE;
 }

--- a/krnl386/kernel.c
+++ b/krnl386/kernel.c
@@ -213,7 +213,7 @@ BOOL WINAPI KERNEL_DllEntryPoint( DWORD reasion, HINSTANCE16 inst, WORD ds,
 #define SET_ENTRY_POINT( num, addr ) \
     NE_SetEntryPoint( inst, (num), GLOBAL_CreateBlock( GMEM_FIXED, \
                       DOSMEM_MapDosToLinear(addr), 0x10000, inst, \
-                      WINE_LDT_FLAGS_DATA ))
+                      WINE_LDT_FLAGS_DATA, 0 ))
 
     SET_ENTRY_POINT( 174, 0xa0000 );  /* KERNEL.174: __A000H */
     SET_ENTRY_POINT( 181, 0xb0000 );  /* KERNEL.181: __B000H */

--- a/krnl386/kernel16_private.h
+++ b/krnl386/kernel16_private.h
@@ -662,10 +662,10 @@ extern UINT   DOSMEM_Available(void) DECLSPEC_HIDDEN;
 
 /* global16.c */
 extern HGLOBAL16 GLOBAL_CreateBlock( UINT16 flags, void *ptr, DWORD size,
-                                     HGLOBAL16 hOwner, unsigned char selflags ) DECLSPEC_HIDDEN;
+                                     HGLOBAL16 hOwner, unsigned char selflags, WORD sel ) DECLSPEC_HIDDEN;
 extern BOOL16 GLOBAL_FreeBlock( HGLOBAL16 handle ) DECLSPEC_HIDDEN;
 extern BOOL16 GLOBAL_MoveBlock( HGLOBAL16 handle, void *ptr, DWORD size ) DECLSPEC_HIDDEN;
-extern HGLOBAL16 GLOBAL_Alloc( WORD flags, DWORD size, HGLOBAL16 hOwner, unsigned char selflags ) DECLSPEC_HIDDEN;
+extern HGLOBAL16 GLOBAL_Alloc( WORD flags, DWORD size, HGLOBAL16 hOwner, unsigned char selflags, WORD sel ) DECLSPEC_HIDDEN;
 
 /* instr.c */
 extern DWORD __wine_emulate_instruction( EXCEPTION_RECORD *rec, CONTEXT *context ) DECLSPEC_HIDDEN;
@@ -682,7 +682,7 @@ extern DWORD NE_StartTask(void) DECLSPEC_HIDDEN;
 /* ne_segment.c */
 extern BOOL NE_LoadSegment( NE_MODULE *pModule, WORD segnum ) DECLSPEC_HIDDEN;
 extern BOOL NE_LoadAllSegments( NE_MODULE *pModule ) DECLSPEC_HIDDEN;
-extern BOOL NE_CreateSegment( NE_MODULE *pModule, int segnum ) DECLSPEC_HIDDEN;
+extern BOOL NE_CreateSegment( NE_MODULE *pModule, int segnum, WORD sel ) DECLSPEC_HIDDEN;
 extern BOOL NE_CreateAllSegments( NE_MODULE *pModule ) DECLSPEC_HIDDEN;
 extern HINSTANCE16 NE_GetInstance( NE_MODULE *pModule ) DECLSPEC_HIDDEN;
 extern void NE_InitializeDLLs( HMODULE16 hModule ) DECLSPEC_HIDDEN;

--- a/krnl386/ne_module.c
+++ b/krnl386/ne_module.c
@@ -1504,7 +1504,7 @@ DWORD NE_StartTask(void)
         hPrevInstance = NE_GetInstance( pModule );
 
         if ( pModule->ne_autodata )
-            if ( NE_CreateSegment( pModule, pModule->ne_autodata ) )
+            if ( NE_CreateSegment( pModule, pModule->ne_autodata, 0 ) )
                 NE_LoadSegment( pModule, pModule->ne_autodata );
 
         hInstance = NE_GetInstance( pModule );

--- a/krnl386/relay.c
+++ b/krnl386/relay.c
@@ -887,7 +887,7 @@ SEGPTR make_thunk_32(void *funcptr, const char *arguments, const char *name, BOO
     assert(ret_32bit);
     if (!thunk32_relay_array)
     {
-        thunk32_relay_segment = GLOBAL_Alloc(GMEM_ZEROINIT, 0x10000, GetModuleHandle16("KERNEL"), WINE_LDT_FLAGS_CODE);
+        thunk32_relay_segment = GLOBAL_Alloc(GMEM_ZEROINIT, 0x10000, GetModuleHandle16("KERNEL"), WINE_LDT_FLAGS_CODE, 0);
         thunk32_relay_array = GlobalLock16(thunk32_relay_segment);
     }
     for (int i = 0; i < 0x10000 / sizeof(PROC16_RELAY); i++)

--- a/krnl386/snoop.c
+++ b/krnl386/snoop.c
@@ -111,7 +111,7 @@ SNOOP16_RegisterDLL(HMODULE16 hModule,LPCSTR name) {
         return;
     }
 	if (!snr) {
-		xsnr=GLOBAL_Alloc(GMEM_ZEROINIT,2*sizeof(*snr),0,WINE_LDT_FLAGS_CODE|WINE_LDT_FLAGS_32BIT);
+		xsnr=GLOBAL_Alloc(GMEM_ZEROINIT,2*sizeof(*snr),0,WINE_LDT_FLAGS_CODE|WINE_LDT_FLAGS_32BIT,0);
 		snr = GlobalLock16(xsnr);
 		snr[0].pushbp	= 0x5566;
 		snr[0].pusheax	= 0x50;
@@ -156,7 +156,7 @@ SNOOP16_RegisterDLL(HMODULE16 hModule,LPCSTR name) {
 	strcpy( (*dll)->name, name );
 	if ((q=strrchr((*dll)->name,'.')))
 		*q='\0';
-	(*dll)->funhandle = GlobalHandleToSel16(GLOBAL_Alloc(GMEM_ZEROINIT,65535,0,WINE_LDT_FLAGS_CODE));
+	(*dll)->funhandle = GlobalHandleToSel16(GLOBAL_Alloc(GMEM_ZEROINIT,65535,0,WINE_LDT_FLAGS_CODE,0));
 	(*dll)->funs = GlobalLock16((*dll)->funhandle);
 	if (!(*dll)->funs) {
 		HeapFree(GetProcessHeap(),0,*dll);
@@ -274,7 +274,7 @@ static void WINAPI SNOOP16_Entry(FARPROC proc, LPBYTE args, CONTEXT *context) {
 		rets = &((*rets)->next);
 	}
 	if (!*rets) {
-		HANDLE16 hand = GlobalHandleToSel16(GLOBAL_Alloc(GMEM_ZEROINIT,65535,0,WINE_LDT_FLAGS_CODE));
+		HANDLE16 hand = GlobalHandleToSel16(GLOBAL_Alloc(GMEM_ZEROINIT,65535,0,WINE_LDT_FLAGS_CODE,0));
 		*rets = GlobalLock16(hand);
 		(*rets)->rethandle = hand;
 		i = 0;	/* entry 0 is free */

--- a/krnl386/task.c
+++ b/krnl386/task.c
@@ -270,7 +270,7 @@ static SEGPTR TASK_AllocThunk(void)
         if (!sel)  /* Allocate a new segment */
         {
             sel = GLOBAL_Alloc( GMEM_FIXED, FIELD_OFFSET( THUNKS, thunks[MIN_THUNKS] ),
-                                pTask->hPDB, WINE_LDT_FLAGS_CODE );
+                                pTask->hPDB, WINE_LDT_FLAGS_CODE, 0 );
             if (!sel) return 0;
             TASK_CreateThunks( sel, 0, MIN_THUNKS );
             pThunk->next = sel;
@@ -370,7 +370,7 @@ static TDB *TASK_Create( NE_MODULE *pModule, UINT16 cmdShow, LPCSTR cmdline, BYT
       /* Allocate a selector for the PDB */
 
     pTask->hPDB = GLOBAL_CreateBlock( GMEM_FIXED, &pTask->pdb, sizeof(PDB16),
-                                      hModule, WINE_LDT_FLAGS_DATA );
+                                      hModule, WINE_LDT_FLAGS_DATA, 0 );
 
       /* Fill the PDB */
 
@@ -414,7 +414,7 @@ static TDB *TASK_Create( NE_MODULE *pModule, UINT16 cmdShow, LPCSTR cmdline, BYT
       /* Allocate a code segment alias for the TDB */
 
     pTask->hCSAlias = GLOBAL_CreateBlock( GMEM_FIXED, pTask, sizeof(TDB),
-                                          pTask->hPDB, WINE_LDT_FLAGS_CODE );
+                                          pTask->hPDB, WINE_LDT_FLAGS_CODE, 0 );
 
       /* Default DTA overwrites command line */
 


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1191
FLWLIB has 3 64K + 1 empty segments that it gets the segment for the first and treats the next as first + AHINCR.  When the library is first loaded it works mostly because the selectors are probably sequential but after some time winevdm will reuse freed selectors causing fragmentation when the library is freed then loaded again.  This preallocates the selectors and make global_alloc able to use the given selector.