### PR TITLE
check that hdc isn't in dc cache in getdc

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -2141,7 +2141,7 @@ BOOL16 WINAPI DeleteDC16( HDC16 hdc )
         return TRUE;
     }
     else if (!GetObjectType(hdc32))
-        return TRUE; // Assume object was already released
+        return TRUE; // Assume object was already released, dc cache may make this unnecessary
     return FALSE;
 }
 

--- a/user/window.c
+++ b/user/window.c
@@ -1151,7 +1151,17 @@ HDC16 WINAPI GetDC16( HWND16 hwnd )
         hdc = GetDC( WIN_Handle32(hwnd) );
     if (IsOldWindowsTask(GetCurrentTask()) && !(get_aflags(GetExePtr(GetCurrentTask())) & NE_AFLAGS_WIN2_PROTMODE) && (GetCurrentObject(hdc, OBJ_FONT) == GetStockObject(SYSTEM_FONT)))
         SelectObject(hdc, GetStockObject(SYSTEM_FIXED_FONT));
-    return HDC_16(hdc);
+    HDC16 hdc16 = HDC_16(hdc);
+    // check the hdc is in the cache becuase it was removed and deleted
+    for (int i = 0; i < 5; i++)
+    {
+        if (dcc.dcs[i] == hdc16)
+        {
+            dcc.dcs[i] = 0;
+            dcc.wnds[i] = 0;
+        }
+    }
+    return hdc16;
 }
 
 


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1193

In https://github.com/otya128/winevdm/issues/133 exile3 calls releasedc and deletedc after getdc and expects both to succeed.  Now released dcs are cached because some programs reference them after calling releasedc but exile then deletes them while they are still cached so when a new dc is created with the same handle they can be deleted when to stale entry is evicted.  This checks for that in getdc.