### PR TITLE
adjust array size so elements don't span a segment boundary

### DIFF
--- a/ole2disp/ole2disp.c
+++ b/ole2disp/ole2disp.c
@@ -101,12 +101,12 @@ static ULONG safearray_size(ULONG cells, WORD cbcell)
 static SEGPTR safearray_ptrofindex(SEGPTR array, ULONG index, WORD cbcell)
 
 {
-    ULONG pos = safearray_size(index, cbcell);
-    return MAKELONG(pos & 0xffff, (pos >> 16) << 3 + HIWORD(array));
+    ULONG pos = safearray_size(index, cbcell) + LOWORD(array);
+    return MAKELONG(pos & 0xffff, ((pos >> 16) << 3) + HIWORD(array));
 }
 
 /* Free data items in an array */
-static HRESULT SAFEARRAY_DestroyData(SAFEARRAY *psa, ULONG ulStartCell)
+static HRESULT SAFEARRAY_DestroyData(SAFEARRAY16 *psa, ULONG ulStartCell)
 {
   if (psa->pvData)
   {

--- a/user/window.c
+++ b/user/window.c
@@ -1732,6 +1732,8 @@ LONG WINAPI SetWindowLong16( HWND16 hwnd16, INT16 offset, LONG newval )
         *(LONG*)(hwndwordbuf[hwnd16] + offset) = newval;
         return old;
     }
+    else if (offset == GWL_HWNDPARENT)
+        return (SetWindowLongA(WIN_Handle32(hwnd), offset, HWND_32(newval)));
     /*else*/ return SetWindowLongA( hwnd, offset, newval );
 }
 


### PR DESCRIPTION
vb4 handles the array internally but uses the safearray function to allocate it.  It expects padding at segment boundaries, without it it will run past the array end.  I had to fix safearrayredim and destroydata to account for this but was only able to test redim.
probably fixes https://github.com/otya128/winevdm/issues/1206