### PR TITLE
send wm_querynewpalette before wm_activateapp in 256 color mode

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -2424,6 +2424,11 @@ LRESULT WINPROC_CallProc32ATo16( winproc_callback16_t callback, HWND hwnd, UINT 
             ret = callback( HWND_16(hwnd), msg, wParam, lParam, result, arg );
         break;
     case WM_ACTIVATEAPP:
+        if (krnl386_get_compat_mode("256color") && (callback == call_window_proc16))
+        {
+            LRESULT res;
+            callback(HWND_16(hwnd), WM_QUERYNEWPALETTE, NULL, NULL, &res, arg);
+        }
         ret = callback( HWND_16(hwnd), msg, wParam, HTASK_16( lParam ), result, arg );
         break;
     case WM_PAINT:


### PR DESCRIPTION
There's still a .5sec delay before the game input works after losing focus but it works better.
fixes https://github.com/otya128/winevdm/issues/1232