### PR TITLE
Don't use a dlgthunk if dlgproc is null

### DIFF
--- a/user/dialog.c
+++ b/user/dialog.c
@@ -743,8 +743,12 @@ static HWND DIALOG_CreateIndirect16(HINSTANCE16 hInst, SEGPTR dlgTemplate16,
     DWORD size;
     DLGTEMPLATEEX *template32 = dialog_template16_to_template32(hInst32, dlgTemplate16, &size, paramd);
     DWORD count;
-    DLGPROC proc = allocate_proc_thunk(paramd, DlgProc_Thunk);
-    paramd->dlgProc = dlgProc;
+    DLGPROC proc = NULL;
+    if (dlgProc)
+    {
+        proc = allocate_proc_thunk(paramd, DlgProc_Thunk);
+        paramd->dlgProc = dlgProc;
+    }
     ReleaseThunkLock(&count);
     if (modal)
     {


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1235
Windows doesn't send wm_initdialog to a dialog with a null dlgproc but winevdm would always set a dlgproc_thunk.   NS5R Sound Editor sends a wm_initdialog to itself and so was getting two of them causing it to create overlapping tabbed dialogs.