### PR TITLE
if dlgproc is null don't pass wm_initdialog to the wndproc

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -5233,6 +5233,8 @@ LRESULT CALLBACK WindowProc16(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam)
         {
             SetMenu(hDlg, get_dialog_hmenu(hDlg));
         }
+        if (!GetDlgProc16(HWND_16(hDlg)))
+            return TRUE;
     }
     WNDPROC16 wndproc16 = (WNDPROC16)GetWndProc16(hWnd16);
     if (wndproc16)


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1235
Windows doesn't send wm_initdialog to a dialog with a null dlgproc so suppress it in windowproc so the menu gets created. NS5R Sound Editor sends a wm_initdialog to itself and so was getting two of them causing it to create overlapping tabbed dialogs.  In this case the second message is sent by sendmessage16 so it doesn't pass though windowproc.