### PR TITLE
if dlgproc is null don't pass wm_initdialog to the wndproc

### DIFF
--- a/user/dialog.c
+++ b/user/dialog.c
@@ -52,12 +52,6 @@ typedef struct
 void free_proc_thunk(DLGPROCTHUNK *thunk);
 BYTE get_aflags(HMODULE16 hModule);
 
-typedef struct
-{
-    HMENU16 hMenu16;
-    DLGPROC16 dlgProc;
-} dialog_data;
-
 /* Dialog control information */
 typedef struct
 {
@@ -677,13 +671,12 @@ static void init_proc_thunk()
     MAX_THUNK = 4096 / sizeof(DLGPROCTHUNK);
     thunk_array = VirtualAlloc(NULL, MAX_THUNK * sizeof(DLGPROCTHUNK), MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 }
-HMENU get_dialog_hmenu(HWND hWnd)
+dialog_data *get_dialog_data(HWND hWnd)
 {
     DLGPROC dlgproc = GetWindowLongPtrA(hWnd, DWLP_DLGPROC);
     if (thunk_array <= dlgproc && thunk_array + MAX_THUNK > dlgproc)
     {
-        DLGPROCTHUNK *thunk = (DLGPROCTHUNK*)dlgproc;
-        return HMENU_32(((dialog_data*)thunk->param)->hMenu16);
+        return (dialog_data*)(((DLGPROCTHUNK *)dlgproc)->param);
     }
     return 0;
 }

--- a/user/user_private.h
+++ b/user/user_private.h
@@ -114,6 +114,12 @@ typedef struct tagDIALOGINFO
     UINT      flags;       /* EndDialog() called for this dialog */
 } DIALOGINFO;
 
+typedef struct
+{
+    HMENU16 hMenu16;
+    DLGPROC16 dlgProc;
+} dialog_data;
+
 #define DF_END  0x0001
 #define DF_OWNERENABLED 0x0002
 


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1235
3rd try check that the dlgthunk exists.  Windows doesn't send wm_initdialog to a dialog with a null dlgproc so suppress it in windowproc so the menu gets created. NS5R Sound Editor sends a wm_initdialog to itself and so was getting two of them causing it to create overlapping tabbed dialogs. In this case the second message is sent by sendmessage16 so it doesn't pass though windowproc.  Also reset dlgproc to null and clean up the unneeded thunk.