### PR TITLE
Pass create msg without converting if lparam is null

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -1539,6 +1539,11 @@ LRESULT WINPROC_CallProc16To32A( winproc_callback_t callback, HWND16 hwnd, UINT1
     case WM_NCCREATE:
     case WM_CREATE:
         {
+            if (!HIWORD(lParam))
+            {
+                ret = callback(hwnd32, msg, wParam, lParam, result, arg);
+                break;
+            }
             CREATESTRUCT16 *cs16 = MapSL(lParam);
             CREATESTRUCTA cs;
             MDICREATESTRUCTA mdi_cs;


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1243
Autosketch passes a wm_erasebknd msg as a wm_create msg.  This appears to be a bug in the program but I don't know what the win32 wndproc for that window does with it.