### PR TITLE
create optional shim for elevated processes

### DIFF
--- a/krnl386/ne_module.c
+++ b/krnl386/ne_module.c
@@ -1359,13 +1359,15 @@ HANDLE WINAPI LoadModule_wine_implementation(LPCSTR name, LPVOID paramBlock, HAN
 #endif
         if (error == ERROR_ELEVATION_REQUIRED)
         {
+            char exename[MAX_PATH];
+            int len = krnl386_get_config_string("otvdm", "ElevationShim", "", exename, sizeof(exename));
             SHELLEXECUTEINFOA sei = { 0 };
             sei.cbSize = sizeof(sei);
             sei.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_CLASSNAME | SEE_MASK_WAITFORINPUTIDLE;
-            sei.lpFile = filename;
-            sei.lpParameters = p;
+            sei.lpFile = len ? exename : filename;
+            sei.lpParameters = len ? cmdline : p;
             sei.nShow = startup.dwFlags ? startup.wShowWindow : SW_NORMAL;
-            sei.lpVerb = "open";
+            sei.lpVerb = "runas";
             sei.lpClass = "exefile";
             if (ShellExecuteExA(&sei))
                 *result = sei.hProcess;

--- a/otvdm.ini
+++ b/otvdm.ini
@@ -111,4 +111,8 @@
 ;font name=1(enumerated)/0(not enumerated)
 ;MS Serif=1
 ;Webdings=0
-;
+
+; Run a compatibility shim for elevated processes
+; isfixload will shim installshield which calls sendmessagea(HWND_BROADCAST) which can hang if there
+; is a process not servicing it's message queue
+;ElevationShim=isfixload.exe


### PR DESCRIPTION
To use with https://github.com/cracyc/installshieldfix .
Installshield calls sendmessagea with hwnd_broadcast which can cause the win32 part to hang just after starting with the progress bar just stuck if there is a nonresponsive process.  It looks to the users like a winevdm problem but since it's in win32, the best that can be done is to launch a shim to detour sendmessagea to sendmessagetimeouta.  Hopefully will help with https://github.com/otya128/winevdm/issues/1245 and https://github.com/otya128/winevdm/issues/226.