### PR TITLE
fix oleloadfromstream so it can load 16bit objects

### DIFF
--- a/compobj/compobj.def
+++ b/compobj/compobj.def
@@ -8,3 +8,4 @@ EXPORTS
   CoInitialize16 @3
   CoUninitialize16 @4
   StringFromGUID216 @5
+  CoCreateInstance16

--- a/compobj/compobj.dll16.spec
+++ b/compobj/compobj.dll16.spec
@@ -221,3 +221,4 @@
 @ stdcall -arch=win32 CoInitialize16(long)
 @ stdcall -arch=win32 CoUninitialize16()
 @ stdcall -arch=win32 StringFromGUID216(ptr ptr long)
+@ stdcall -arch=win32 CoCreateInstance16(long long long long long)

--- a/ole2/ole2.c
+++ b/ole2/ole2.c
@@ -1040,6 +1040,7 @@ HRESULT WINAPI OleLoadFromStream16(SEGPTR pStm, SEGPTR sriid, SEGPTR sppvObj)
     ifpstm = MapLS(&IID_IPersistStream);
     result = IUnknown16_QueryInterface(*ppvObj, ifpstm, pxstm);
     UnMapLS(pxstm);
+    UnMapLS(ifpstm);
     if (FAILED(result))
     {
         IUnknown16_Release(*ppvObj);

--- a/ole2/ole2.dll16.spec
+++ b/ole2/ole2.dll16.spec
@@ -23,7 +23,7 @@
 22 pascal BindMoniker(segptr long ptr ptr) BindMoniker16
 23 pascal MkParseDisplayName(segptr str ptr ptr) MkParseDisplayName16
 24 pascal OleSaveToStream(segptr segptr) OleSaveToStream16
-25 pascal OleLoadFromStream(segptr ptr ptr) OleLoadFromStream16
+25 pascal OleLoadFromStream(segptr segptr segptr) OleLoadFromStream16
 26 pascal CreateBindCtx(long ptr) CreateBindCtx16
 27 pascal CreateItemMoniker(str str ptr) CreateItemMoniker16
 28 pascal CreateFileMoniker(str ptr) CreateFileMoniker16


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1267

If 32bit objects aren't loaded properly despite CoCreateInstance16 calling CoCreateInstance then stream will need to be seeked back to 0 and a call to 32bit oleloadfromstream will be needed.