### PR TITLE
remove olecli hack, add wait before getmessage and don't set clipboar…

### DIFF
--- a/olecli/olecli.c
+++ b/olecli/olecli.c
@@ -435,10 +435,6 @@ OLESTATUS WINAPI OleCreate16(LPCSTR name, SEGPTR client, LPCSTR xname, LHCLIENTD
     LPOLECLIENT client32 = get_ole_client32(client);
     LPOLEOBJECT obj32 = 0;
     OLESTATUS status = OleCreate(name, client32, xname, hclientdoc, xxname, &obj32, render, format);
-    // sometimes the server starts but winexec times out too quickly. since it's started a second
-    // try can connect to the running instance
-    if (status == OLE_ERROR_COMM)
-        status = OleCreate(name, client32, xname, hclientdoc, xxname, &obj32, render, format);
     *oleobject = OLEOBJ16(obj32);
     return status;
 }
@@ -520,10 +516,6 @@ OLESTATUS WINAPI OleActivate16(SEGPTR oleobj, UINT uint, BOOL b1, BOOL b2, HWND1
     }
     ReleaseThunkLock(&count);
     OLESTATUS status = OleActivate(oleobj32, uint, b1, b2, HWND_32(hwnd), rect ? &rect32 : NULL);
-    // sometimes the server starts but winexec times out too quickly. since it's started a second
-    // try can connect to the running instance
-    if (status == OLE_ERROR_COMM)
-        status = OleActivate(oleobj32, uint, b1, b2, HWND_32(hwnd), rect ? &rect32 : NULL);
     RestoreThunkLock(count);
     return status;
 }

--- a/otvdm/winevdm.c
+++ b/otvdm/winevdm.c
@@ -908,6 +908,7 @@ int entry_point( int argc, char *argv[] )
     ReleaseThunkLock(&count);
     if (use_shared_wow_server)
         run_shared_wow_server();
+    Sleep(1000);  // sleep for a second so the loaded task can start, allows waitforinputidle to work
     while (TRUE)
     {
         MSG msg;

--- a/user/message.c
+++ b/user/message.c
@@ -1426,7 +1426,7 @@ static HDROP hdrop16_to_hdrop32(HDROP16 hdrop16)
 }
 
 // TODO: check for and fix memory leaks
-HANDLE convert_cb_data_16_32(int format, HANDLE16 data16);
+HANDLE convert_cb_data_16_32(int format, HANDLE16 data16, BOOL set_format);
 static void convert_dde_msg_16_to_32(int msg, UINT_PTR handle)
 {
     void *ptr = (void *)GlobalLock((HGLOBAL)handle);
@@ -1444,11 +1444,11 @@ static void convert_dde_msg_16_to_32(int msg, UINT_PTR handle)
             break;
     }
     if (data && (format < 0xc000) && (format != CF_TEXT) && (format != CF_OEMTEXT) && *(HANDLE16 *)data)
-        *(HANDLE *)data = convert_cb_data_16_32(format, *(HANDLE16 *)data);
+        *(HANDLE *)data = convert_cb_data_16_32(format, *(HANDLE16 *)data, FALSE);
     GlobalUnlock((HGLOBAL)handle);
 }
 
-HANDLE16 convert_cb_data_32_16(int format, HANDLE data32);
+HANDLE16 convert_cb_data_32_16(int format, HANDLE data32, BOOL set_format);
 static void convert_dde_msg_32_to_16(int msg, HANDLE16 handle)
 {
     void *ptr = (void *)GlobalLock16(handle);
@@ -1466,7 +1466,7 @@ static void convert_dde_msg_32_to_16(int msg, HANDLE16 handle)
             break;
     }
     if (data && (format < 0xc000) && (format != CF_TEXT) && (format != CF_OEMTEXT) && *(HANDLE *)data)
-        *(HANDLE16 *)data = convert_cb_data_32_16(format, *(HANDLE *)data);
+        *(HANDLE16 *)data = convert_cb_data_32_16(format, *(HANDLE *)data, FALSE);
     GlobalUnlock16(handle);
 }
         

--- a/user/user.c
+++ b/user/user.c
@@ -1038,7 +1038,7 @@ BOOL16 WINAPI EmptyClipboard16(void)
     return ret;
 }
 
-HANDLE convert_cb_data_16_32(int format, HANDLE16 data16)
+HANDLE convert_cb_data_16_32(int format, HANDLE16 data16, BOOL set_format)
 {
     HANDLE data32 = 0;
     switch (format)
@@ -1066,7 +1066,8 @@ HANDLE convert_cb_data_16_32(int format, HANDLE16 data16)
             GlobalUnlock16( pict16->hMF );
             GlobalUnlock( data32 );
         }
-        set_clipboard_format( format, data16 );
+        if (set_format)
+            set_clipboard_format( format, data16 );
         break;
     }
 
@@ -1090,7 +1091,8 @@ HANDLE convert_cb_data_16_32(int format, HANDLE16 data16)
                 memcpy( ptr32, ptr16, size );
                 GlobalUnlock( data32 );
             }
-            set_clipboard_format( format, data16 );
+            if (set_format)
+                set_clipboard_format( format, data16 );
         }
         break;
     }
@@ -1103,11 +1105,11 @@ HANDLE convert_cb_data_16_32(int format, HANDLE16 data16)
  */
 HANDLE16 WINAPI SetClipboardData16( UINT16 format, HANDLE16 data16 )
 {
-    if (!SetClipboardData( format, convert_cb_data_16_32(format, data16) )) return 0;
+    if (!SetClipboardData( format, convert_cb_data_16_32(format, data16, TRUE) )) return 0;
     return data16;
 }
 
-HANDLE16 convert_cb_data_32_16(int format, HANDLE data32)
+HANDLE16 convert_cb_data_32_16(int format, HANDLE data32, BOOL set_format)
 {
     UINT size;
     HANDLE16 data16 = 0;
@@ -1137,7 +1139,8 @@ HANDLE16 convert_cb_data_32_16(int format, HANDLE data32)
             GetMetaFileBitsEx( pict32->hMF, size, ptr );
             GlobalUnlock16( pict16->hMF );
             GlobalUnlock16( data16 );
-            set_clipboard_format( format, data16 );
+            if (set_format)
+                set_clipboard_format( format, data16 );
         }
         break;
     }
@@ -1161,7 +1164,8 @@ HANDLE16 convert_cb_data_32_16(int format, HANDLE data32)
                 ptr16 = GlobalLock16( data16 );
                 memcpy( ptr16, ptr32, size );
                 GlobalUnlock16( data16 );
-                set_clipboard_format( format, data16 );
+                if (set_format)
+                    set_clipboard_format( format, data16 );
             }
         }
         break;
@@ -1178,7 +1182,7 @@ HANDLE16 WINAPI GetClipboardData16( UINT16 format )
     HANDLE data32 = GetClipboardData( format );
 
     if (!data32) return 0;
-    return convert_cb_data_32_16(format, data32);
+    return convert_cb_data_32_16(format, data32, TRUE);
 }
 
 


### PR DESCRIPTION
…d when receiving dde messages

Ole really only works properly when using otvdmw.exe as it uses waitforinputidle and that doesn't work with console programs.  The hack only worked with win16 ole clients so just remove it since it the real solution is to use otvdmw.  Also wait before getmessagea in winevdm.c so ole servers have a chance to create their ole server windows otherwise waitforinputidle returns too quickly.  The set_clipboard change fixes a crash when using the equation editor ole server.