### PR TITLE
Adjust dpmi get selector base for dosmem and return 1 (hardware defau…

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -2279,6 +2279,7 @@ INT16 WINAPI GetDeviceCaps16( HDC16 hdc, INT16 cap )
         }
     }
     else if (((cap == NUMCOLORS) || (cap == NUMPENS)) && (ret == -1)) ret = 2048;
+    else if (cap == VREFRESH) ret = 1;
     if (krnl386_get_compat_mode("640X480") && (GetDeviceCaps(hdc32, TECHNOLOGY) == DT_RASDISPLAY))
     {
         switch (cap)

--- a/krnl386/int31.c
+++ b/krnl386/int31.c
@@ -1057,7 +1057,7 @@ void WINAPI DOSVM_Int31Handler( CONTEXT *context )
             }
             else
             {
-                void *base = wine_ldt_get_base(&entry);
+                void *base = GetSelectorBase(sel);
                 SET_CX( context, HIWORD(base) );
                 SET_DX( context, LOWORD(base) );
             }


### PR DESCRIPTION
…lt) for vrefresh in GetDeviceCaps

Fixes Just Grandma and Me.   VREFRESH was added for win95 so I doubt many win16 programs use it and that program gets confused if it doesn't return 1.