### PR TITLE
save the last freed selector and if possible reuse it for the next al…

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -718,6 +718,14 @@ BOOL16 WINAPI EndPaint16( HWND16 hwnd, const PAINTSTRUCT16* lps )
     BOOL result = EndPaint( WIN_Handle32(hwnd), &ps );
     if (result)
     {
+        for (int i = 0; i < 5; i++)
+        {
+            if (dcc.dcs[i] == lps->hdc)
+            {
+                dcc.dcs[i] = 0;
+                dcc.wnds[i] = 0;
+            }
+        }
         K32WOWHandle16DestroyHint(ps.hdc, WOW_TYPE_HDC);
     }
     return result;


### PR DESCRIPTION
…location
fixes https://github.com/otya128/winevdm/issues/1271
The program uses globalfree followed a little later with globalalloc and the selectors must be the same.  This works in win31 and ntvdm because the selectors a placed on a stack like linked list.  Hopefully there is no program with frees more than one selector and expects them to be allocated in reverse order.