### PR TITLE
call remove_wndproc on child windows too

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -119,7 +119,8 @@ BOOL CALLBACK remove_wndproc(HWND hwnd, LPARAM lparam)
 {
     if (GetExePtr(GetWindowWord16(HWND_16(hwnd), GWL_HINSTANCE)) == lparam)
     {
-        TRACE("HWND %p WNDPROC removed\n");
+        TRACE("HWND %x WNDPROC removed\n", hwnd);
+        EnumChildWindows(hwnd, remove_wndproc, lparam);
         SetWindowLongPtrA(hwnd, GWLP_WNDPROC, DefWindowProcA);
     }
     return TRUE;
@@ -132,10 +133,10 @@ BOOL CALLBACK enum_thread_window(HWND hwnd, LPARAM lparam)
     {
         if (GetWindowLongPtrA(hwnd, GWLP_WNDPROC) != DefWindowProcA)
         {
-            TRACE("HWND %p WNDPROC removed\n");
+            TRACE("HWND %x WNDPROC removed\n", hwnd);
             SetWindowLongPtrA(hwnd, GWLP_WNDPROC, DefWindowProcA);
         }
-        TRACE("HWND %p destroyed\n");
+        TRACE("HWND %x destroyed\n", hwnd);
         DestroyWindow(hwnd);
     }
     return TRUE;


### PR DESCRIPTION
fixes installer for https://github.com/otya128/winevdm/issues/1271 where child window has focus and when parent is destroyed wm_killfocus is sent to child after the task is gone.