### PR TITLE
call nfy_delmodule in freelibrary and don't call a getmessage hook fo…

### DIFF
--- a/krnl386/ne_module.c
+++ b/krnl386/ne_module.c
@@ -1645,8 +1645,11 @@ static BOOL16 NE_FreeModule( HMODULE16 hModule, BOOL call_wep, BOOL cleanup )
 
     /* Free the objects owned by the DLL module */
     if (cleanup)
+    {
+        if (pModule->ne_flags & NE_FFLAGS_LIBMODULE)
+            TOOLHELP_CallNotify(NFY_DELMODULE, hModule);
         NE_CallUserSignalProc( hModule, USIG16_DLL_UNLOAD, 0, 0, 0 );
-
+    }
 
     if (call_wep && !(pModule->ne_flags & NE_FFLAGS_WIN32))
     {

--- a/user/hook.c
+++ b/user/hook.c
@@ -532,6 +532,8 @@ static LRESULT CALLBACK call_WH_GETMESSAGE( INT code, WPARAM wp, LPARAM lp, BOOL
     LRESULT result;
     CallNextHookEx(get_hhook(WH_GETMESSAGE, global), code, wp, lp);
 
+    if (global && !msg->hwnd) return 1; // XXX: a thread message can cause the hook to be called in the wrong context
+
     params.time   = msg->time;
     params.pt.x   = msg->pt.x;
     params.pt.y   = msg->pt.y;


### PR DESCRIPTION
…r task messages

fixes https://github.com/otya128/winevdm/issues/1287

Redshift uses quicktime which loads qtnotify.exe at start.  It calls a function in qtim.dll when it is unloaded but if qtim is unloaded first it watches for nfy_delmodule and calls it then.  This causes a crash in redshift since nfy_delmodule is never sent and it tries to call it at exit but qtim is already freed.  This then causes another crash where qtnotify sends a message to itself using postappmessage so it will exit after qtim but the redshift task has a global getmessage hook which is then called in the qtnotify context.  I made it to not call global getmessage hooks if the message has a null hwnd.