### PR TITLE
don't call setscrollinfo with an invalid range and convert a dib to a…

### DIFF
--- a/user/user.c
+++ b/user/user.c
@@ -1044,6 +1044,28 @@ HANDLE convert_cb_data_16_32(int format, HANDLE16 data16, BOOL set_format)
     switch (format)
     {
     case CF_BITMAP:
+    {
+        DIBSECTION dib;
+        data32 = HGDIOBJ_32(data16);
+        if (GetObject(data32, sizeof(DIBSECTION), &dib))
+        {
+            HDC hdcsrc = CreateCompatibleDC(NULL);
+            HDC hdcdst = CreateCompatibleDC(NULL);
+            HDC hdc = GetDC(NULL);
+            HBITMAP hbmp = CreateCompatibleBitmap(hdc, dib.dsBm.bmWidth, dib.dsBm.bmHeight);
+            ReleaseDC(NULL, hdc);
+            HBITMAP oldhbmpsrc = SelectObject(hdcsrc, data32);
+            HBITMAP oldhbmpdst = SelectObject(hdcdst, hbmp);
+            BitBlt(hdcdst, 0, 0, dib.dsBm.bmWidth, dib.dsBm.bmHeight, hdcsrc, 0, 0, SRCCOPY);
+            SelectObject(hdcsrc, oldhbmpsrc);
+            SelectObject(hdcdst, oldhbmpdst);
+            DeleteDC(hdcsrc);
+            DeleteDC(hdcdst);
+            DeleteObject(data32);
+            data32 = hbmp;
+        }
+        break;
+    }
     case CF_PALETTE:
         data32 = HGDIOBJ_32( data16 );
         break;

--- a/user/user.c
+++ b/user/user.c
@@ -1047,7 +1047,7 @@ HANDLE convert_cb_data_16_32(int format, HANDLE16 data16, BOOL set_format)
     {
         DIBSECTION dib;
         data32 = HGDIOBJ_32(data16);
-        if (GetObject(data32, sizeof(DIBSECTION), &dib))
+        if (GetObject(data32, sizeof(DIBSECTION), &dib) == sizeof(DIBSECTION))
         {
             HDC hdcsrc = CreateCompatibleDC(NULL);
             HDC hdcdst = CreateCompatibleDC(NULL);

--- a/user/window.c
+++ b/user/window.c
@@ -1078,9 +1078,18 @@ INT16 WINAPI GetScrollPos16( HWND16 hwnd, INT16 nBar )
  */
 void WINAPI SetScrollRange16( HWND16 hwnd, INT16 nBar, INT16 MinVal, INT16 MaxVal, BOOL16 redraw )
 {
+    HWND hwnd32 = HWND_32(hwnd);
     /* Invalid range -> range is set to (0,0) */
     if ((INT)MaxVal - (INT)MinVal > 0x7fff) MinVal = MaxVal = 0;
-    SetScrollRange( WIN_Handle32(hwnd), nBar, MinVal, MaxVal, redraw );
+    // don't create a scrollbar if none is wanted
+    if (MinVal == MaxVal)
+    {
+        INT min, max;
+        GetScrollRange(hwnd32, nBar, &min, &max);
+        if (GetLastError() == ERROR_NO_SCROLLBARS)
+            return;
+    }
+    SetScrollRange(hwnd32, nBar, MinVal, MaxVal, redraw);
 }
 
 

--- a/user/window.c
+++ b/user/window.c
@@ -1085,8 +1085,8 @@ void WINAPI SetScrollRange16( HWND16 hwnd, INT16 nBar, INT16 MinVal, INT16 MaxVa
     if (MinVal == MaxVal)
     {
         INT min, max;
-        GetScrollRange(hwnd32, nBar, &min, &max);
-        if (GetLastError() == ERROR_NO_SCROLLBARS)
+        GetScrollRange(hwnd32, nBar, &min, &max); // always returns TRUE
+        if (!min && !max && GetLastError() == ERROR_NO_SCROLLBARS)
             return;
     }
     SetScrollRange(hwnd32, nBar, MinVal, MaxVal, redraw);


### PR DESCRIPTION
… bitmap before setting it to the clipboard if type is cf_bitmap

The program in https://github.com/otya128/winevdm/issues/1271 sets a bitmap to the clipboard but we, to fix other issues, will sometimes create a dib instead of a ddb.  The clipboard won't accept a dib section for cf_bitmap but cf_dib must be a bmp formatted dib not a dib section so just convert it first (windows for some reason won't do it but actually does convert it later if the clipboard reader requests it).   Also, the program calls SetScrollRange(0,0) for each scrollbar to make sure they are disabled but during the second call windows 7+ will set the first to 0,100 anyway so just skip calling setscrollrange if the range is null and there is no existing scrollbar (win7 ntvdm has some other workaround for this but I couldn't find it, winxp doesn't have this program at all).