### PR TITLE
delete mmiofile dos handle if one was needed

### DIFF
--- a/krnl386/file.c
+++ b/krnl386/file.c
@@ -371,7 +371,7 @@ HFILE WINAPI Win32HandleToDosFileHandle( HANDLE handle )
  *       this because of the way our DOS handles are implemented.
  *       It shouldn't break anything though.
  */
-void WINAPI DisposeLZ32Handle( HANDLE handle )
+BOOL16 WINAPI DeleteDosFileHandle( HANDLE handle )
 {
     int i;
 
@@ -381,10 +381,9 @@ void WINAPI DisposeLZ32Handle( HANDLE handle )
         if (dos_handles[i] == handle)
         {
             dos_handles[i] = 0;
-            /* lzexpand.dll16 uses wine-based lzexpand implementation. so call _lclose instead of LZClose */
-            _lclose( handle );
-            break;
+            return TRUE;
         }
+    return FALSE;
 }
 
 /***********************************************************************

--- a/krnl386/krnl386.def
+++ b/krnl386/krnl386.def
@@ -24,7 +24,7 @@ EXPORTS
   GetProcessDword @19
   DosFileHandleToWin32Handle @20
   Win32HandleToDosFileHandle @21
-  DisposeLZ32Handle @22
+  DeleteDosFileHandle @22
   GlobalAlloc16 @23
   GlobalLock16 @24
   GlobalUnlock16 @25

--- a/krnl386/krnl386.exe16.spec
+++ b/krnl386/krnl386.exe16.spec
@@ -569,7 +569,7 @@
 @ stdcall -arch=win32 GetProcessDword(long long)
 @ stdcall -arch=win32 DosFileHandleToWin32Handle(long)
 @ stdcall -arch=win32 Win32HandleToDosFileHandle(long)
-@ stdcall -arch=win32 DisposeLZ32Handle(long)
+@ stdcall -arch=win32 DeleteDosFileHandle(long)
 @ stdcall -arch=win32 GlobalAlloc16(long long)
 @ stdcall -arch=win32 GlobalLock16(long)
 @ stdcall -arch=win32 GlobalUnlock16(long)

--- a/lzexpand/lzexpand.c
+++ b/lzexpand/lzexpand.c
@@ -135,7 +135,12 @@ HFILE16 WINAPI LZOpenFile16(LPSTR fn, LPOFSTRUCT ofs, UINT16 mode)
 void WINAPI LZClose16( HFILE16 fd )
 {
     if (IS_LZ_HANDLE(fd)) LZClose( fd );
-    else DisposeLZ32Handle( DosFileHandleToWin32Handle((HFILE)fd) );
+    else
+    {
+        HANDLE fh = DosFileHandleToWin32Handle((HFILE)fd);
+        if (DeleteDosFileHandle(fh))
+            CloseHandle(fh);
+    }
 }
 
 

--- a/lzexpand/wine_lzexpand.c
+++ b/lzexpand/wine_lzexpand.c
@@ -572,7 +572,8 @@ void WINAPI LZClose( HFILE fd )
         {
             HeapFree( GetProcessHeap(), 0, lzs->get );
             lzstates[fd - LZ_MIN_HANDLE] = NULL;
-            DisposeLZ32Handle(lzs->realfd);
+            if (DeleteDosFileHandle(lzs->realfd))
+                CloseHandle(lzs->realfd);
             HeapFree( GetProcessHeap(), 0, lzs );
         }
 }

--- a/mmsystem/mmio16.c
+++ b/mmsystem/mmio16.c
@@ -381,6 +381,14 @@ HMMIO16 WINAPI mmioOpen16(LPSTR szFileName, MMIOINFO16* lpmmioinfo16,
 MMRESULT16 WINAPI mmioClose16(HMMIO16 hmmio, UINT16 uFlags)
 {
     MMRESULT ret;
+    MMIOINFO mmioinfo;
+    HMMIO hmmio32 = HMMIO_32(hmmio);
+
+    if (!(uFlags & MMIO_FHOPEN) && !mmioGetInfo(hmmio32, &mmioinfo, 0))
+    {
+        if (mmioinfo.fccIOProc == FOURCC_DOS)
+            DisposeLZ32Handle(mmioinfo.adwInfo[0]);
+    }
 
     EnterCriticalSection(&mmio_cs);
     ret = mmioClose(HMMIO_32(hmmio), uFlags);

--- a/mmsystem/mmio16.c
+++ b/mmsystem/mmio16.c
@@ -381,22 +381,22 @@ HMMIO16 WINAPI mmioOpen16(LPSTR szFileName, MMIOINFO16* lpmmioinfo16,
 MMRESULT16 WINAPI mmioClose16(HMMIO16 hmmio, UINT16 uFlags)
 {
     MMRESULT ret;
-    MMIOINFO mmioinfo;
     HMMIO hmmio32 = HMMIO_32(hmmio);
+    MMIOINFO mmioinfo = {0};
 
-    if (!(uFlags & MMIO_FHOPEN) && !mmioGetInfo(hmmio32, &mmioinfo, 0))
-    {
-        if (mmioinfo.fccIOProc == FOURCC_DOS)
-            DisposeLZ32Handle(mmioinfo.adwInfo[0]);
-    }
+    if (!(uFlags & MMIO_FHOPEN))
+        mmioGetInfo(hmmio32, &mmioinfo, 0);
 
     EnterCriticalSection(&mmio_cs);
-    ret = mmioClose(HMMIO_32(hmmio), uFlags);
+    ret = mmioClose(hmmio32, uFlags);
     if (ret == MMSYSERR_NOERROR)
     {
         struct mmio_thunk* thunk;
 
-        if ((thunk = MMIO_HasThunk(HMMIO_32(hmmio))))
+        if (mmioinfo.fccIOProc == FOURCC_DOS)
+            DeleteDosFileHandle(mmioinfo.adwInfo[0]);
+
+        if ((thunk = MMIO_HasThunk(hmmio32)))
         {
             MMIO_SetSegmentedBuffer(thunk, 0, TRUE);
             thunk->pfn16 = NULL;

--- a/wine/wine/winbase16.h
+++ b/wine/wine/winbase16.h
@@ -350,7 +350,7 @@ WORD        WINAPI AllocSelector16(WORD);
 WORD        WINAPI AllocSelectorArray16(WORD);
 VOID        WINAPI DirectedYield16(HTASK16);
 HGLOBAL16   WINAPI DirectResAlloc16(HINSTANCE16,WORD,UINT16);
-void        WINAPI DisposeLZ32Handle(HANDLE);
+BOOL16      WINAPI DeleteDosFileHandle(HANDLE);
 HANDLE      WINAPI DosFileHandleToWin32Handle(HFILE);
 HANDLE16    WINAPI FarGetOwner16(HGLOBAL16);
 VOID        WINAPI FarSetOwner16(HGLOBAL16,HANDLE16);


### PR DESCRIPTION
Civ2 uses the borland crt which as compiled rejects file handles greater than 20 even though winevdm supports up to 256.