### PR TITLE
post a message in taskswitch to wake task if needed, don't yield in d…

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -5296,3 +5296,10 @@ BOOL WINAPI DllEntryPoint(DWORD fdwReason, HINSTANCE hinstDLL, WORD ds,
     }
     return TRUE;
 }
+
+HFONT16 WINAPI GetSystemIconFont16()
+{
+    // only known to be used by Simplified Chinese progman
+    // uses SPI_GETICONTITLELOGFONT if this returns 0
+    return 0;
+}

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -3476,19 +3476,12 @@ BOOL16 WINAPI GetRasterizerCaps16( LPRASTERIZER_STATUS lprs, UINT16 cbNumBytes )
 INT16 WINAPI EnumFontFamilies16( HDC16 hDC, LPCSTR lpFamily,
                                  FONTENUMPROC16 efproc, LPARAM lpData )
 {
-    LOGFONT16 lf, *plf;
+    struct callback16_info info;
 
-    if (lpFamily)
-    {
-        if (!*lpFamily) return 1;
-        lstrcpynA( lf.lfFaceName, lpFamily, LF_FACESIZE );
-        lf.lfCharSet = DEFAULT_CHARSET;
-        lf.lfPitchAndFamily = 0;
-        plf = &lf;
-    }
-    else plf = NULL;
-
-    return EnumFontFamiliesEx16( hDC, plf, efproc, lpData, 0 );
+    info.proc = (FARPROC16)efproc;
+    info.param = lpData;
+    info.result = 1;
+    return EnumFontFamiliesA(HDC_32(hDC), lpFamily, enum_font_callback, (LPARAM)&info);
 }
 
 

--- a/gdi/gdi.exe16.spec
+++ b/gdi/gdi.exe16.spec
@@ -106,7 +106,8 @@
 106 pascal   SetBitmapBits(word long ptr) SetBitmapBits16
 # ??? (not even in W1.1)
 117 pascal   SetDCOrg(word s_word s_word) SetDCOrg16
-118 stub InternalCreateDC # W1.1, W2.0
+# 118 stub InternalCreateDC # W1.1, W2.0
+118 pascal -ret16 GetSystemIconFont() GetSystemIconFont16
 119 pascal -ret16 AddFontResource(str) AddFontResource16
 120 stub GetContinuingTextExtent # W1.1, W2.0
 121 pascal -ret16 Death(word) Death16

--- a/krnl386/kernel.c
+++ b/krnl386/kernel.c
@@ -1171,6 +1171,7 @@ DWORD WINAPI TaskGetCSIP16(HTASK16 htask)
 BOOL WINAPI TaskSwitch16(HTASK16 htask, SEGPTR dwNewCSIP)
 {
     BOOL s = TaskSetCSIP16(htask, SELECTOROF(dwNewCSIP), OFFSETOF(dwNewCSIP));
+    PostThreadMessage(HTASK_32(htask), 0, 0, 0);
     if (s)
     {
         DirectedYield16(htask);

--- a/krnl386/kernel.c
+++ b/krnl386/kernel.c
@@ -1171,7 +1171,7 @@ DWORD WINAPI TaskGetCSIP16(HTASK16 htask)
 BOOL WINAPI TaskSwitch16(HTASK16 htask, SEGPTR dwNewCSIP)
 {
     BOOL s = TaskSetCSIP16(htask, SELECTOROF(dwNewCSIP), OFFSETOF(dwNewCSIP));
-    PostThreadMessage(HTASK_32(htask), 0, 0, 0);
+    PostThreadMessageA(HTASK_32(htask), 0, 0, 0);
     if (s)
     {
         DirectedYield16(htask);

--- a/krnl386/kernel.c
+++ b/krnl386/kernel.c
@@ -1171,9 +1171,9 @@ DWORD WINAPI TaskGetCSIP16(HTASK16 htask)
 BOOL WINAPI TaskSwitch16(HTASK16 htask, SEGPTR dwNewCSIP)
 {
     BOOL s = TaskSetCSIP16(htask, SELECTOROF(dwNewCSIP), OFFSETOF(dwNewCSIP));
-    PostThreadMessageA(HTASK_32(htask), 0, 0, 0);
     if (s)
     {
+        PostThreadMessageA(HTASK_32(htask), 0, 0, 0);
         DirectedYield16(htask);
     }
     return s;


### PR DESCRIPTION
…efframeproc if yield_event exists and add getsystemiconfont stub

helps https://github.com/otya128/winevdm/issues/1309 and fixes https://github.com/otya128/winevdm/issues/1306

Taskswitch in win31 toolhelp.dll sends a null app message to wake a task so do that here too.  Borland ide debugger needs to not yield in directedyield when defframeproc is called.