### PR TITLE
Allow freeing of 0 size hglobal.

### DIFF
--- a/krnl386/global.c
+++ b/krnl386/global.c
@@ -228,11 +228,6 @@ BOOL16 GLOBAL_FreeBlock( HGLOBAL16 handle )
     sel = GlobalHandleToSel16( handle );
     if (!VALID_HANDLE(sel)) return FALSE;
     pArena = GET_ARENA_PTR(sel);
-    if (!pArena->size)
-    {
-        WARN( "already free %x\n", handle );
-        return FALSE;
-    }
     SELECTOR_FreeBlock( sel );
     clear_sel_table(sel, pArena->selCount);
     memset( pArena, 0, sizeof(GLOBALARENA) );


### PR DESCRIPTION
The PC98 cdrom manual viewer, https://archive.org/details/pc-9800-tdb-cd, allocates 0 sized global handles while printing which then fail to be freed causing a very large handle leak.