### PR TITLE
support autosubclass and fix colored frames

### DIFF
--- a/ctl3dv2/ctl3d.c
+++ b/ctl3dv2/ctl3d.c
@@ -89,6 +89,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
         TlsFree(autosubclass_index);
         break;
     case DLL_THREAD_DETACH:
+    {
         struct autosubclass *asc = TlsGetValue(autosubclass_index);
         if (asc)
         {
@@ -96,6 +97,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
             HeapFree(GetProcessHeap(), 0, asc);
         }
         break;
+    }
     }
     return TRUE;
 }

--- a/ctl3dv2/ctl3d.c
+++ b/ctl3dv2/ctl3d.c
@@ -171,7 +171,7 @@ static LRESULT CALLBACK subclassproc(INT code, WPARAM wp, LPARAM lp)
                 DWORD exstyle = cbt_cw->lpcs->dwExStyle;
                 ctl3d_static(asc->type, &style, &exstyle);
                 cbt_cw->lpcs->style = style;
-                cbt_cw->lpcs->dwExStyle = style;
+                cbt_cw->lpcs->dwExStyle = exstyle;
                 SetWindowLongA(wp, GWL_STYLE, style);
                 SetWindowLongA(wp, GWL_EXSTYLE, exstyle);
             }

--- a/ctl3dv2/ctl3d.c
+++ b/ctl3dv2/ctl3d.c
@@ -342,6 +342,7 @@ BOOL16 WINAPI Ctl3dUnAutoSubclass16(void)
     {
         UnhookWindowsHookEx(asc->hook);
         HeapFree(GetProcessHeap(), 0, asc);
+        TlsSetValue(autosubclass_index, 0);
     }
     return FALSE;
 }


### PR DESCRIPTION
See https://github.com/otya128/winevdm/issues/1330 where the static rect is supposed to have a raised edge but instead is blacked out.