### PR TITLE
add int31 allocate specific descriptor, pass cmdline to libmain, fix …

### DIFF
--- a/krnl386/int31.c
+++ b/krnl386/int31.c
@@ -1133,13 +1133,14 @@ void WINAPI DOSVM_Int31Handler( CONTEXT *context )
             LDT_ENTRY entry;
             WORD sel = BX_reg(context);
             wine_ldt_get_entry(sel, &entry);
-            if (wine_ldt_get_flags(&entry) & WINE_LDT_FLAGS_ALLOCATED)
+            if (wine_ldt_copy.flags[sel >> __AHSHIFT] & WINE_LDT_FLAGS_ALLOCATED)
             {
                 SET_AX( context, 0x8011 ); /* descriptor unavailable */
                 SET_CFLAG( context );
             }
             else
             {
+                wine_ldt_copy.flags[sel >> __AHSHIFT] |= WINE_LDT_FLAGS_ALLOCATED;
                 wine_ldt_set_flags(&entry, WINE_LDT_FLAGS_DATA);
                 wine_ldt_set_base(&entry, 0);
                 wine_ldt_set_limit(&entry, 0);

--- a/krnl386/kernel16_private.h
+++ b/krnl386/kernel16_private.h
@@ -685,7 +685,7 @@ extern BOOL NE_LoadAllSegments( NE_MODULE *pModule ) DECLSPEC_HIDDEN;
 extern BOOL NE_CreateSegment( NE_MODULE *pModule, int segnum, WORD sel ) DECLSPEC_HIDDEN;
 extern BOOL NE_CreateAllSegments( NE_MODULE *pModule ) DECLSPEC_HIDDEN;
 extern HINSTANCE16 NE_GetInstance( NE_MODULE *pModule ) DECLSPEC_HIDDEN;
-extern void NE_InitializeDLLs( HMODULE16 hModule ) DECLSPEC_HIDDEN;
+extern void NE_InitializeDLLs( HMODULE16 hModule, SEGPTR cmdline ) DECLSPEC_HIDDEN;
 extern void NE_DllProcessAttach( HMODULE16 hModule ) DECLSPEC_HIDDEN;
 extern void NE_CallUserSignalProc( HMODULE16 hModule, UINT16 code, WORD arg1, WORD arg2, WORD arg3 ) DECLSPEC_HIDDEN;
 

--- a/krnl386/selector.c
+++ b/krnl386/selector.c
@@ -532,6 +532,7 @@ void WINAPI UnMapLS( SEGPTR sptr )
  */
 LPVOID WINAPI MapSL( SEGPTR sptr )
 {
+    if (!(SELECTOROF(sptr) & 4)) return OFFSETOF(sptr);
     return (char *)wine_ldt_copy.base[SELECTOROF(sptr) >> __AHSHIFT] + OFFSETOF(sptr);
 }
 

--- a/krnl386/task.c
+++ b/krnl386/task.c
@@ -865,7 +865,7 @@ void WINAPI InitTask16( CONTEXT *context )
         LocalInit16( GlobalHandleToSel16(pTask->hInstance), 0, LOWORD(context->Ecx) );
 
     /* Initialize implicitly loaded DLLs */
-    NE_InitializeDLLs( pTask->hModule );
+    NE_InitializeDLLs( pTask->hModule, NULL );
     NE_DllProcessAttach( pTask->hModule );
 
     /* Registers on return are:

--- a/user/window.c
+++ b/user/window.c
@@ -2530,7 +2530,11 @@ BOOL16 WINAPI SetWindowPlacement16( HWND16 hwnd, const WINDOWPLACEMENT16 *wp16 )
     wpl.rcNormalPosition.top    = wp16->rcNormalPosition.top;
     wpl.rcNormalPosition.right  = wp16->rcNormalPosition.right;
     wpl.rcNormalPosition.bottom = wp16->rcNormalPosition.bottom;
-    return SetWindowPlacement( WIN_Handle32(hwnd), &wpl );
+    DWORD count;
+    ReleaseThunkLock(&count);
+    BOOL ret = SetWindowPlacement( WIN_Handle32(hwnd), &wpl );
+    RestoreThunkLock(count);
+    return ret;
 }
 
 struct WNDCLASS16Info WNDCLASS16Info[65536];

--- a/vm86/mame/emu/cpu/i386/i386ops.c
+++ b/vm86/mame/emu/cpu/i386/i386ops.c
@@ -1137,11 +1137,19 @@ static void I386OP(repeat)(int invert_flag)
 		m_segment_prefix=1;
 		break;
 		case 0x66:
-		m_operand_size ^= 1;
-		m_xmm_operand_size ^= 1;
+		if(!m_operand_prefix)
+		{
+			m_operand_size ^= 1;
+			m_xmm_operand_size ^= 1;
+			m_operand_prefix = 1;
+		}
 		break;
 		case 0x67:
-		m_address_size ^= 1;
+		if(!m_address_prefix)
+		{
+			m_address_size ^= 1;
+			m_address_prefix = 1;
+		}
 		break;
 		default:
 		prefix_flag=0;

--- a/wine/ldt2.c
+++ b/wine/ldt2.c
@@ -67,7 +67,6 @@ int wine_ldt_set_entry(unsigned short sel, const LDT_ENTRY *entry)
 {
 	int ret = 0, index = sel >> 3;
 	ret = TRUE;
-	if (index < LDT_FIRST_ENTRY) return 0;  /* cannot modify reserved entries */
 	if (ret >= 0)
 	{
         wine_ldt[index] = *entry;
@@ -214,8 +213,6 @@ unsigned short wine_ldt_realloc_entries(unsigned short sel, int oldcount, int ne
 static int internal_set_entry(unsigned short sel, const LDT_ENTRY *entry)
 {
 	int ret = 0, index = sel >> 3;
-
-	if (index < LDT_FIRST_ENTRY) return 0;  /* cannot modify reserved entries */
 
 	if (ret >= 0)
 	{


### PR DESCRIPTION
…dde additem for files in the winevdm windows directory, fix cpu bug with prefixes

see https://github.com/otya128/winevdm/issues/1341

Since winevdm doesn't modify the real ldt removing the system entries block shouldn't be an issue.  Also, 64bit windows doesn't even have an ldt.