### PR TITLE
fix dialog create for windows 11 22h2 which removed some ntvdm suppor…

### DIFF
--- a/krnl386/compat.c
+++ b/krnl386/compat.c
@@ -1,4 +1,5 @@
 #include <Windows.h>
+#include "kernel16_private.h"
 
 // this only currently will get the flags for the first task
 // it might be work on a per-task basis
@@ -78,4 +79,15 @@ void WINAPI krnl386_set_compat_path(const LPCSTR path)
     for (int i = 0; i < size; i++)
         modes[i] = tolower(modes[i]);
     return;
+}
+
+ULONG WINAPI get_windows_build()
+{
+    static ULONG build = 0;
+    if (build) return build;
+    RTL_OSVERSIONINFOEXW winver;
+    if (RtlGetVersion(&winver))
+        return 0;
+    build = winver.dwBuildNumber;
+    return build;
 }

--- a/krnl386/krnl386.def
+++ b/krnl386/krnl386.def
@@ -244,3 +244,4 @@ EXPORTS
   vm_inject
   set_vm_inject_cb
   get_idle_event
+  get_windows_build

--- a/krnl386/krnl386.exe16.spec
+++ b/krnl386/krnl386.exe16.spec
@@ -799,3 +799,4 @@
 @ stdcall -arch=win32 set_vm_inject_cb(long)
 @ stdcall -arch=win32 vm_inject(long long long long long)
 @ stdcall -arch=win32 get_idle_event()
+@ stdcall -arch=win32 get_windows_build()


### PR DESCRIPTION
…t code

This needs more testing for win16 dialogs, older windows versions (but the build version check should be sufficient) and whether the 22h2 cutoff is correct (elsewhere i've seen that build identified as when userregisterwowhandlers was removed, https://github.com/microsoft/terminal/issues/15038#issuecomment-1627004640).  Also there might be other user32 breakage to fix.

fixes https://github.com/otya128/winevdm/issues/1354