### PR TITLE
fix hang in olecreate and correct display size in 640x480 compat mode

### DIFF
--- a/ddeml/ddeml.c
+++ b/ddeml/ddeml.c
@@ -264,6 +264,7 @@ UINT16 WINAPI DdeInitialize16(LPDWORD pidInst, PFNCALLBACK16 pfnCallback,
 			      DWORD afCmd, DWORD ulRes)
 {
     UINT16 ret;
+    DWORD count;
     struct ddeml_thunk* thunk;
     // Undocumented 0x800 causes DdeClientTransaction to call DdeUninitialize which will likely
     // create a deadlock with XTYP_EXECUTE if the client and server are in the same process
@@ -271,6 +272,7 @@ UINT16 WINAPI DdeInitialize16(LPDWORD pidInst, PFNCALLBACK16 pfnCallback,
     // MF_POSTMSGS causes also deadlocks in DdeDisconnect in the client thread
     afCmd &= ~MF_POSTMSGS;
 
+    ReleaseThunkLock(&count);
     EnterCriticalSection(&ddeml_cs);
     if ((thunk = DDEML_AddThunk(*pidInst, (DWORD)pfnCallback)))
     {
@@ -279,6 +281,7 @@ UINT16 WINAPI DdeInitialize16(LPDWORD pidInst, PFNCALLBACK16 pfnCallback,
     }
     else ret = DMLERR_SYS_ERROR;
     LeaveCriticalSection(&ddeml_cs);
+    RestoreThunkLock(count);
     return ret;
 }
 

--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -2290,6 +2290,12 @@ INT16 WINAPI GetDeviceCaps16( HDC16 hdc, INT16 cap )
             case VERTRES:
                 ret = 480;
                 break;
+            case HORZSIZE:
+                ret = 169;
+                break;
+            case VERTSIZE:
+                ret = 127;
+                break;
         }
     }
     return ret;

--- a/krnl386/int2f.c
+++ b/krnl386/int2f.c
@@ -1027,7 +1027,6 @@ static void MSCDEX_Handler(CONTEXT* context)
 
     case 0x0D: /* get drive letters */
        p = CTX_SEG_OFF_TO_LIN(context, context->SegEs, context->Ebx);
-       memset(p, 0, 26);
        for (drive = 0; drive < 26; drive++) {
            if (is_cdrom(drive)) *p++ = drive;
        }

--- a/olecli/olecli.c
+++ b/olecli/olecli.c
@@ -434,7 +434,10 @@ OLESTATUS WINAPI OleCreate16(LPCSTR name, SEGPTR client, LPCSTR xname, LHCLIENTD
 {
     LPOLECLIENT client32 = get_ole_client32(client);
     LPOLEOBJECT obj32 = 0;
+    DWORD count;
+    ReleaseThunkLock(&count);
     OLESTATUS status = OleCreate(name, client32, xname, hclientdoc, xxname, &obj32, render, format);
+    RestoreThunkLock(count);
     *oleobject = OLEOBJ16(obj32);
     return status;
 }

--- a/regedit/regedit.c
+++ b/regedit/regedit.c
@@ -147,21 +147,6 @@ static void processRegLinesA(FILE *in)
                 continue;
             }
 
-            /* If there is a concatenating '\\', go around again */
-            if (*(s_eol - 1) == '\\') {
-                char *next_line = s_eol + 1;
-
-                if (*s_eol == '\r' && *(s_eol + 1) == '\n')
-                    next_line++;
-
-                while (*(next_line + 1) == ' ' || *(next_line + 1) == '\t')
-                    next_line++;
-
-                MoveMemory(s_eol - 1, next_line, chars_in_buf - (next_line - s) + 1);
-                chars_in_buf -= next_line - s_eol + 1;
-                continue;
-            }
-
             /* Remove any line feed. Leave s_eol on the last \0 */
             if (*s_eol == '\r' && *(s_eol + 1) == '\n')
                 *s_eol++ = '\0';
@@ -247,7 +232,13 @@ int WINAPI WinMain16(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 {
     LPSTR s = lpCmdLine;        /* command line pointer */
     CHAR ch = *s;               /* current character */
-    
+   
+    while (isspace(ch))
+    {
+        s++;
+        ch = *s;
+    } 
+ 
     while (ch && ((ch == '-') || (ch == '/')))
     {
         char chu;

--- a/regedit/regedit.c
+++ b/regedit/regedit.c
@@ -34,6 +34,7 @@
 
 #define REG_VAL_BUF_SIZE        4096
 DWORD WINAPI RegSetValue16(HKEY hkey, LPCSTR name, DWORD type, LPCSTR data, DWORD count);
+LPCSTR RedirectSystemDir(LPCSTR path, LPSTR to, size_t max_len);
 
 /* version for Windows 3.1 */
 static void processRegEntry31(char *line)
@@ -300,6 +301,14 @@ int WINAPI WinMain16(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     while(filename[0])
     {
         reg_file = fopen(filename, "r");
+        if (!reg_file) // start dir for regedit should be the windows dir
+        {
+            char regdir[MAX_PATH];
+            RedirectSystemDir("C:\\WINDOWS", regdir, MAX_PATH);
+            strcat(regdir, "\\");
+            strcat(regdir, filename);
+            reg_file = fopen(regdir, "r");
+        }
         if (reg_file)
         {
             processRegLinesA(reg_file);

--- a/toolhelp/toolhelp.c
+++ b/toolhelp/toolhelp.c
@@ -807,6 +807,7 @@ BOOL WINAPI TOOLHELP_CallNotify(WORD wID, DWORD dwData)
         {
             skip = TRUE;  // task is likely dead
         }
+        __ENDTRY
         if (skip) continue;
         sssp = getWOW32Reserved();
         args[2] = wID;

--- a/toolhelp/toolhelp.c
+++ b/toolhelp/toolhelp.c
@@ -38,6 +38,7 @@
 #include "wine/winbase16.h"
 #include "toolhelp.h"
 #include "wine/debug.h"
+#include "wine/exception.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(toolhelp);
 
@@ -788,6 +789,7 @@ BOOL WINAPI TOOLHELP_CallNotify(WORD wID, DWORD dwData)
     {
         WORD args[3];
         PVOID sssp;
+        BOOL skip = FALSE;
         if ((wID == NFY_TASKIN || wID == NFY_TASKOUT) && (notifys[i].wFlags & NF_TASKSWITCH) != NF_TASKSWITCH)
         {
             continue;
@@ -796,6 +798,16 @@ BOOL WINAPI TOOLHELP_CallNotify(WORD wID, DWORD dwData)
         {
             continue;
         }
+        __TRY
+        {
+            // TODO: call notifiers in own thread
+            skip = !IsTask16(GetCurrentTask()) || ((notifys[i].htask & 3) != 3);
+        }
+        __EXCEPT_ALL
+        {
+            skip = TRUE;  // task is likely dead
+        }
+        if (skip) continue;
         sssp = getWOW32Reserved();
         args[2] = wID;
         args[1] = HIWORD(dwData);


### PR DESCRIPTION
wpwin 6 calculates the dpi with horzsize, vertsize, horzres and vertres and on large displays that can cause an underflow when it sign extends after a divide with the high bit set which breaks the cursor position.  Setting to 640x480 mode fixes it after horzsize and vertsize are corrected.