### PR TITLE
remove showwindow hack

### DIFF
--- a/user/message.c
+++ b/user/message.c
@@ -4857,11 +4857,7 @@ LRESULT CALLBACK WndProcHook(int code, WPARAM wParam, LPARAM lParam)
                 if (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x30a)
                     SendMessageA(pcwp->hwnd, WM_SETVISIBLE, pcwp->wParam, 0);
                 if (aero_diasble)
-                {
                     SetWindowTheme(pcwp->hwnd, L"", L"");
-                    if (GetMenu(pcwp->hwnd) && !(GetWindowLongA(pcwp->hwnd, GWL_STYLE) & WS_CHILD))
-                        SetWindowPos(pcwp->hwnd, 0, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOSIZE | SWP_NOMOVE);
-                }
             }
         }
     }


### PR DESCRIPTION
This reverts https://github.com/otya128/winevdm/pull/544 as the problem doesn't seem to occur on windows 11 and it causes Tomcat Alley to crash at start.