### PR TITLE
add ini option to change dpi value returned from getdevicecaps

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -2298,6 +2298,20 @@ INT16 WINAPI GetDeviceCaps16( HDC16 hdc, INT16 cap )
                 break;
         }
     }
+    int newdpi = krnl386_get_config_int("otvdm", "AdjustDPI", FALSE);
+    if (newdpi)
+    {
+        switch (cap)
+        {
+            case LOGPIXELSX:
+                ret = newdpi;
+                break;
+            case LOGPIXELSY:
+                ret = newdpi;
+                break;
+        }
+    }
+
     return ret;
 }
 

--- a/otvdm.ini
+++ b/otvdm.ini
@@ -116,3 +116,8 @@
 ; isfixload will shim installshield which calls sendmessagea(HWND_BROADCAST) which can hang if there
 ; is a process not servicing it's message queue
 ;ElevationShim=isfixload.exe
+
+; Adjust the dpi for programs, especially visual basic, which use dpi for calculating
+; font and window sizes but can get an integer overflow on large displays, can also
+; make text larger in some cases
+;AdjustDPI=120


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1384

Mordor always maximizes the main window. With the default dpi it can overflow a 16bit int when calculating the window size in twips on large displays.