### PR TITLE
enable loading of win16 video codecs and fix the wait delay in mcisen…

### DIFF
--- a/krnl386/krnl386.def
+++ b/krnl386/krnl386.def
@@ -245,3 +245,4 @@ EXPORTS
   set_vm_inject_cb
   get_idle_event
   get_windows_build
+  GetSelectorLimit16

--- a/krnl386/krnl386.exe16.spec
+++ b/krnl386/krnl386.exe16.spec
@@ -728,6 +728,7 @@
 @ stdcall -arch=win32 LockResource16(long)
 @ stdcall -arch=win32 SetSelectorBase(long long)
 @ stdcall -arch=win32 SetSelectorLimit16(long long)
+@ stdcall -arch=win32 GetSelectorLimit16(long)
 @ stdcall -arch=win32 SizeofResource16(long long)
 @ stdcall -arch=win32 WinExec16(str long)
 

--- a/msvideo/msvideo16.c
+++ b/msvideo/msvideo16.c
@@ -819,6 +819,7 @@ static  LRESULT CALLBACK  IC_Callback3216(DWORD pfn16, HIC hic, HDRVR hdrv, UINT
         lp2 = (LPARAM)(MapLS(lp2));
         break;
     case ICM_DECOMPRESS:
+    {
         ICDECOMPRESS *icdec16 = HeapAlloc(GetProcessHeap(), 0, sizeof(ICDECOMPRESS));
         ICDECOMPRESS *icdec = lp1;
 
@@ -851,7 +852,7 @@ static  LRESULT CALLBACK  IC_Callback3216(DWORD pfn16, HIC hic, HDRVR hdrv, UINT
         lp1 = (LPARAM)(MapLS(icdec16));
         lp2 = sizeof(ICDECOMPRESS);
         break;
-
+    }
     }
     args[7] = HIWORD(hic);
     args[6] = LOWORD(hic);


### PR DESCRIPTION
…dstring

Madeline’s Thinking Games uses a codec arbc which apparently never had a 32bit version.  Icinstall with icinstall_function can be used to install a thunk so the codec can work with vfw32.dll.  The program also uses mcisendstring with wait which hits the same problem as mcisendcommand does with a 300ms sleep which hangs the playback so use the same trick to run the message queue.