### PR TITLE
clear carry in vtd gettime and restore fs on function return

### DIFF
--- a/krnl386/vxd.c
+++ b/krnl386/vxd.c
@@ -644,6 +644,7 @@ void WINAPI __wine_vxd_timer( CONTEXT *context )
 
 	context->Edx = context->Eax >> 22;
 	context->Eax <<= 10; /* not very precise */
+	RESET_CFLAG(context);
 	break;
 
     case 0x0101: /* current Windows time, msecs */

--- a/vm86/msdos.cpp
+++ b/vm86/msdos.cpp
@@ -1718,8 +1718,8 @@ try_again:
                         /* Some programs expect that gs is not a valid selector! */
                         /* Some programs expect that fs is not a valid selector! */
                         /* win16 sets 0? */
-                        SREG(FS) = 0;//(WORD)context.SegFs == reg_fs ? 0 : context.SegFs;
-                        SREG(GS) = 0;//(WORD)context.SegGs == reg_gs ? 0 : context.SegGs;
+                        SREG(FS) = (WORD)context.SegFs == reg_fs ? 0 : context.SegFs;
+                        SREG(GS) = (WORD)context.SegGs == reg_gs ? 0 : context.SegGs;
                         if (reg)
                         {
                             if (!(ip19 != context.Eip || cs16 != context.SegCs))


### PR DESCRIPTION
ChromaZone uses vxd calls to get the tick count and expects carry to be clear on success.  It also expects fs and gs to be saved across the call.  I'm not sure if there are programs that expect them to be 0 on return, if there are some way to save them only across vxd calls should be found or maybe it's good enough to check if there selectors are invalid and just clear them in that case.

re: https://github.com/otya128/winevdm/issues/1394