### PR TITLE
set fs and gs to 0 in globalfree

### DIFF
--- a/krnl386/global.c
+++ b/krnl386/global.c
@@ -798,6 +798,8 @@ DWORD WINAPI WIN16_GlobalFlags16(HGLOBAL16 handle)
 DWORD WINAPI WIN16_GlobalFree16(HGLOBAL16 handle)
 {
     CURRENT_STACK16->es = 0;
+    CURRENT_STACK16->fs = 0;
+    CURRENT_STACK16->gs = 0;
     return GlobalFree16(handle);
 }
 void regen_icon(HICON16 icon);

--- a/vm86/msdos.cpp
+++ b/vm86/msdos.cpp
@@ -1718,8 +1718,8 @@ try_again:
                         /* Some programs expect that gs is not a valid selector! */
                         /* Some programs expect that fs is not a valid selector! */
                         /* win16 sets 0? */
-                        SREG(FS) = (WORD)context.SegFs == reg_fs ? 0 : context.SegFs;
-                        SREG(GS) = (WORD)context.SegGs == reg_gs ? 0 : context.SegGs;
+                        SREG(FS) = reg ? (WORD)context.SegFs : (WORD)oa->fs;
+                        SREG(GS) = reg ? (WORD)context.SegGs : (WORD)oa->gs;
                         if (reg)
                         {
                             if (!(ip19 != context.Eip || cs16 != context.SegCs))


### PR DESCRIPTION
Verified that windows 3.1 and ntvdm do this.
Fixes https://github.com/otya128/winevdm/issues/1433