### PR TITLE
if the task is dead then don't even try to call a notifier as there's…

### DIFF
--- a/toolhelp/toolhelp.c
+++ b/toolhelp/toolhelp.c
@@ -801,7 +801,7 @@ BOOL WINAPI TOOLHELP_CallNotify(WORD wID, DWORD dwData)
         __TRY
         {
             // TODO: call notifiers in own thread
-            skip = ((notifys[i].htask & 3) == 3) && !IsTask16(GetCurrentTask());
+            skip = !IsTask16(GetCurrentTask());
         }
         __EXCEPT_ALL
         {


### PR DESCRIPTION
… no stack
fixes https://github.com/otya128/winevdm/issues/1441
Toolhelp should call in the context of the task that set the notifier but since it doesn't right now if the current task is dead then we cant call anything.