### PR TITLE
VerifyConsoleIoHandle always returns 0 on Windows 11 so use GetConsol…

### DIFF
--- a/krnl386/int21.c
+++ b/krnl386/int21.c
@@ -2816,12 +2816,13 @@ static void INT21_Ioctl_Char( CONTEXT *context )
     BOOL IsConsoleIOHandle = FALSE;
     IO_STATUS_BLOCK io;
     FILE_INTERNAL_INFORMATION info;
+    DWORD mode;
     HANDLE handle = DosFileHandleToWin32Handle(BX_reg(context));
 
     status = NtQueryInformationFile( handle, &io, &info, sizeof(info), FileInternalInformation );
     if (status)
     {
-        if( VerifyConsoleIoHandle( handle))
+        if( GetConsoleMode(handle, &mode) )
             IsConsoleIOHandle = TRUE;
         else {
             SET_AX( context, RtlNtStatusToDosError(status) );


### PR DESCRIPTION
…eMode instead
fixes part of https://github.com/otya128/winevdm/issues/1445