### PR TITLE
make redrawwindow in realizepalette configurable

### DIFF
--- a/otvdm.ini
+++ b/otvdm.ini
@@ -106,6 +106,9 @@
 ; Emulate 8bpp color mode using DIBs (default: 0)
 ;DIBPalette=0
 
+; Redraw the window when a palette is realized in 8bpp mode (default: 0)
+;RealizeRedraw=0
+
 ; If EnumFontLimitation=1, this section declare the font to be enumerated.
 ;[EnumFontLimitation]
 ;font name=1(enumerated)/0(not enumerated)

--- a/user/user.c
+++ b/user/user.c
@@ -2281,7 +2281,8 @@ UINT16 WINAPI RealizePalette16( HDC16 hdc )
             && (GetDeviceCaps(hdc32, TECHNOLOGY) == DT_RASDISPLAY) && (GetObjectType(hdc32) == OBJ_DC))
             set_realized_palette(hdc32);
         HWND hwnd = WindowFromDC(hdc32);
-        if (hwnd) RedrawWindow(hwnd, NULL, NULL, RDW_INTERNALPAINT);
+        if (hwnd && krnl386_get_config_int("otvdm", "RealizeRedraw", FALSE))
+            RedrawWindow(hwnd, NULL, NULL, RDW_INTERNALPAINT);
     }
         
     return UserRealizePalette(hdc32);


### PR DESCRIPTION
Quicktime calls realizepalette in wm_paint so this causes an infinite loop.  