### PR TITLE
set the current directory to lpdir in shellexecute then set it back o…

### DIFF
--- a/shell/shell.c
+++ b/shell/shell.c
@@ -706,7 +706,11 @@ static UINT_PTR SHELL_Execute16(const WCHAR *lpCmd, WCHAR *env, BOOL shWait,
 static UINT_PTR WINAPI SHELL_Execute16_Windows(const CHAR *lpCmd, int nShowCmd, const CHAR *lpDir)
 {
 	UINT ret;
+	char currdir[MAX_PATH];
+	GetCurrentDirectoryA(MAX_PATH, currdir);
+	SetCurrentDirectoryA(lpDir);
 	ret = WinExec16(lpCmd, nShowCmd);
+	SetCurrentDirectoryA(currdir);
 	return ret;
 }
 


### PR DESCRIPTION
…n return
This appears to be what ntvdm does.
fixes maybe https://github.com/otya128/winevdm/issues/1451