### PR TITLE
work around change in 24h2 forcing ws_ex_windowedge on 3.1 windows

### DIFF
--- a/user/dialog.c
+++ b/user/dialog.c
@@ -141,12 +141,7 @@ static LPCSTR DIALOG_GetControl16( LPCSTR p, DLG_CONTROL_INFO *info )
     {
         switch((BYTE)*p)
         {
-            case 0x80: strcpy( buffer, "BUTTON" );
-                // this is undocumented but makes BS_USERBUTTON work
-                // BS_ICON and BS_BITMAP work without it
-                if (((info->style & 0xf) == BS_USERBUTTON) && !(info->style & 0xc0))
-                    info->style |= 0x10;
-                break;
+            case 0x80: strcpy( buffer, "BUTTON" ); break;
             case 0x81: strcpy( buffer, "EDIT" ); break;
             case 0x82: strcpy( buffer, "STATIC" ); break;
             case 0x83: strcpy( buffer, "LISTBOX" ); break;

--- a/user/message.c
+++ b/user/message.c
@@ -1902,7 +1902,7 @@ LRESULT WINPROC_CallProc16To32A( winproc_callback_t callback, HWND16 hwnd, UINT1
         if ((get_windows_build() >= 26100) && (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x400))
         {
             LONG style = GetWindowLongA(hwnd32, GWL_STYLE);
-            if ((style & (WS_CHILD | WS_SYSMENU | WS_BORDER | WS_DLGFRAME | WS_CAPTION)) == (WS_CHILD | WS_SYSMENU | WS_BORDER | WS_DLGFRAME | WS_CAPTION))
+            if ((style & (WS_SYSMENU | WS_BORDER | WS_DLGFRAME | WS_CAPTION)) == (WS_SYSMENU | WS_BORDER | WS_DLGFRAME | WS_CAPTION))
             {
                 HICON icon = SendMessageA(hwnd32, WM_GETICON, ICON_SMALL, 0);
                 if (!icon)

--- a/user/message.c
+++ b/user/message.c
@@ -1898,9 +1898,22 @@ LRESULT WINPROC_CallProc16To32A( winproc_callback_t callback, HWND16 hwnd, UINT1
     case WM_SIZECLIPBOARD:
         FIXME_(msg)( "message %04x needs translation\n", msg );
         break;
-	case WM_NCPAINT:
+    case WM_NCPAINT:
+        if ((get_windows_build() >= 26100) && (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x400))
+        {
+            LONG style = GetWindowLongA(hwnd32, GWL_STYLE);
+            if ((style & (WS_CHILD | WS_SYSMENU | WS_BORDER | WS_DLGFRAME | WS_CAPTION)) == (WS_CHILD | WS_SYSMENU | WS_BORDER | WS_DLGFRAME | WS_CAPTION))
+            {
+                HICON icon = SendMessageA(hwnd32, WM_GETICON, ICON_SMALL, 0);
+                if (!icon)
+                {
+                    icon = SendMessageA(hwnd32, WM_QUERYDRAGICON, 0, 0);
+                    if (icon) SendMessageA(hwnd32, WM_SETICON, ICON_SMALL, icon);
+                }
+            }
+        }
         ret = callback(hwnd32, msg, (WPARAM)HRGN_32(wParam), lParam, result, arg);
-		break;
+        break;
     case WM_ERASEBKGND:
         ret = callback(hwnd32, msg, (WPARAM)HDC_32(wParam), lParam, result, arg);
         break;

--- a/user/message.c
+++ b/user/message.c
@@ -4879,7 +4879,7 @@ static void UB_Message(HWND hwnd, HDC hDC, UINT action)
     if (action == BN_SETFOCUS)
         DrawFocusRect(hDC, &rc);
 
-    SendMessageW(parent, WM_COMMAND, MAKEWPARAM(GetWindowLongA(hwnd, GWLP_ID), action), hwnd);
+    SendMessageW(parent, WM_COMMAND, MAKEWPARAM(GetWindowLongW(hwnd, GWLP_ID), action), hwnd);
 }
 
 static LRESULT UB_WndProc(HWND hwnd, UINT umsg, WPARAM wparam, LPARAM lparam)
@@ -4890,7 +4890,7 @@ static LRESULT UB_WndProc(HWND hwnd, UINT umsg, WPARAM wparam, LPARAM lparam)
         case WM_PAINT:
         {
             PAINTSTRUCT paint;
-            LONG style = GetWindowLongA(hwnd, GWL_STYLE);
+            LONG style = GetWindowLongW(hwnd, GWL_STYLE);
             LONG state = SendMessageW(hwnd, BM_GETSTATE, 0, 0);
             HDC hDC = BeginPaint(hwnd, &paint);
             UB_Message(hwnd, hDC, BN_PAINT);
@@ -4916,7 +4916,7 @@ static LRESULT UB_WndProc(HWND hwnd, UINT umsg, WPARAM wparam, LPARAM lparam)
             break;
         }
         case WM_LBUTTONDBLCLK:
-            SendMessageW(GetParent(hwnd), WM_COMMAND, MAKEWPARAM(GetWindowLongA(hwnd, GWLP_ID), BN_DOUBLECLICKED), hwnd);
+            SendMessageW(GetParent(hwnd), WM_COMMAND, MAKEWPARAM(GetWindowLongW(hwnd, GWLP_ID), BN_DOUBLECLICKED), hwnd);
             break;
         default:
         {

--- a/user/message.c
+++ b/user/message.c
@@ -1902,7 +1902,7 @@ LRESULT WINPROC_CallProc16To32A( winproc_callback_t callback, HWND16 hwnd, UINT1
         if ((get_windows_build() >= 26100) && (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x400))
         {
             LONG style = GetWindowLongA(hwnd32, GWL_STYLE);
-            if ((style & (WS_SYSMENU | WS_BORDER | WS_DLGFRAME | WS_CAPTION)) == (WS_SYSMENU | WS_BORDER | WS_DLGFRAME | WS_CAPTION))
+            if ((style & (WS_SYSMENU | WS_CAPTION)) == (WS_SYSMENU | WS_CAPTION))
             {
                 HICON icon = SendMessageA(hwnd32, WM_GETICON, ICON_SMALL, 0);
                 if (!icon)

--- a/user/window.c
+++ b/user/window.c
@@ -3138,7 +3138,6 @@ HWND16 WINAPI CreateWindowEx16( DWORD exStyle, LPCSTR className,
     HWND hwnd;
     BOOL release = FALSE;
     DWORD count;
-    BOOL fix_windowedge = FALSE;
 
     if (instance == NULL)
     {
@@ -3181,7 +3180,7 @@ HWND16 WINAPI CreateWindowEx16( DWORD exStyle, LPCSTR className,
     {
         if (((style & (WS_CAPTION | WS_SIZEBOX)) == WS_CAPTION) && !(style & WS_CHILD) && !(exStyle && (WS_EX_DLGMODALFRAME | WS_EX_WINDOWEDGE)) &&
             (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x400))
-            fix_windowedge = TRUE;
+            exStyle |= WS_EX_STATICEDGE;
     }
 
     /* Create the window */
@@ -3245,13 +3244,6 @@ HWND16 WINAPI CreateWindowEx16( DWORD exStyle, LPCSTR className,
         return NULL;
     }
 
-    if (fix_windowedge)
-    {
-        DWORD curexstyle = GetWindowLongA(hwnd, GWL_EXSTYLE);
-        if (curexstyle & WS_EX_WINDOWEDGE)
-            SetWindowLongA(hwnd, GWL_EXSTYLE, (curexstyle & ~WS_EX_WINDOWEDGE) | WS_EX_STATICEDGE);
-    }
-        
     HWND16 hWnd16 = HWND_16(hwnd);
 	InitWndProc16(hwnd, hWnd16);
     SetWindowHInst16(hWnd16, instance);

--- a/user/window.c
+++ b/user/window.c
@@ -3176,7 +3176,7 @@ HWND16 WINAPI CreateWindowEx16( DWORD exStyle, LPCSTR className,
     // even though they are supposed to be mutually exclusive
     if (get_windows_build() >= 26100)
     {
-        if (((style & (WS_CAPTION | WS_SIZEBOX)) == WS_CAPTION) && !(style & WS_CHILD) && !(exStyle && (WS_EX_DLGMODALFRAME | WS_EX_WINDOWEDGE)) &&
+        if (((style & (WS_CAPTION | WS_SIZEBOX)) == WS_CAPTION) && !(style & WS_CHILD) && !(exStyle & (WS_EX_DLGMODALFRAME | WS_EX_WINDOWEDGE)) &&
             (GetExpWinVer16(GetExePtr(GetCurrentTask())) < 0x400))
             exStyle |= WS_EX_STATICEDGE;
     }

--- a/user/window.c
+++ b/user/window.c
@@ -3170,8 +3170,6 @@ HWND16 WINAPI CreateWindowEx16( DWORD exStyle, LPCSTR className,
         if ((style & (WS_CAPTION | WS_SIZEBOX)) == (WS_CAPTION | WS_SIZEBOX))
             style |= WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
     }
-    if (((style & 0xf) == BS_USERBUTTON) && !(style & 0xc0) && !stricmp(className, "Button"))
-        style |= 0x10; // BS_USERBUTTON support hack        
 
     // work around WS_EX_WINDOWEDGE 3.10 compat breakage in Windows 11 24H2
     // must be done after create because otherwise both windowedge and staticedge get set


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1468

Using ws_ex_staticedge doesn't look quite right but it doesn't shrink the window.  This should also affect win32 nt 3.1 programs so since it's not dead code like the wow stuff maybe it'll be fixed in the future.