### PR TITLE
dialogbox should return -1 if the dialog resource isn't found and set…

### DIFF
--- a/user/dialog.c
+++ b/user/dialog.c
@@ -1009,8 +1009,8 @@ INT16 WINAPI DialogBoxParam16( HINSTANCE16 hInst, LPCSTR template,
     SEGPTR data;
     int ret = -1;
 
-    if (!(hRsrc = FindResource16( hInst, template, (LPSTR)RT_DIALOG ))) return 0;
-    if (!(hmem = LoadResource16( hInst, hRsrc ))) return 0;
+    if (!(hRsrc = FindResource16( hInst, template, (LPSTR)RT_DIALOG ))) return -1;
+    if (!(hmem = LoadResource16( hInst, hRsrc ))) return -1;
     if ((data = WOWGlobalLock16( hmem )))
     {
         HWND owner = WIN_Handle32(owner16);

--- a/user/window.c
+++ b/user/window.c
@@ -356,6 +356,7 @@ UINT16 WINAPI SetTimer16( HWND16 hwnd, UINT16 id, UINT16 timeout, TIMERPROC16 pr
 {
     TIMERPROC proc32;
     UINT ret;
+    timeout = timeout < 55 ? 55 : timeout;
     if (proc == NULL)
     {
         return SetTimer(WIN_Handle32(hwnd), id, timeout, NULL);


### PR DESCRIPTION
…timer minimum is 55ms

fixes https://github.com/otya128/winevdm/issues/1475

55ms is the minimum on win31 and ntvdm