### PR TITLE
handle blts to 8bit dibs better

### DIFF
--- a/user/user.c
+++ b/user/user.c
@@ -924,6 +924,7 @@ INT16 WINAPI FillRect16( HDC16 hdc, const RECT16 *rect, HBRUSH16 hbrush )
                 PatBlt( hdc32, rect->left, rect->top,
                         rect->right - rect->left, rect->bottom - rect->top, PATCOPY );
                 SelectObject( hdc32, prevBrush );
+                DeleteObject( newbrush );
                 return 1;
             }
         }

--- a/user/user.def
+++ b/user/user.def
@@ -6,6 +6,7 @@ EXPORTS
   _wine_spec_dos_header @1 DATA;=.L__wine_spec_dos_header @1 DATA PRIVATE
   CreateIcon16 @2
   CreateIconFromResourceEx16
+  SelectPalette16
   dialog_template16_to_template32
   DIALOG_CallDialogProc
   __wine_call_wndproc

--- a/user/user.exe16.spec
+++ b/user/user.exe16.spec
@@ -588,6 +588,7 @@
 #
 @ stdcall -arch=win32 CreateIcon16(long long long long long ptr ptr)
 @ stdcall -arch=win32 CreateIconFromResourceEx16(ptr long long long long long long)
+@ stdcall -arch=win32 SelectPalette16(long long long)
 @ stdcall -arch=win32 dialog_template16_to_template32(long long ptr ptr)
 @ stdcall -arch=win32 DIALOG_CallDialogProc(ptr long ptr ptr ptr)
 @ stdcall -arch=win32 __wine_call_wndproc(long long long long long)


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1473 and https://github.com/otya128/winevdm/issues/1410
fixes partially https://github.com/otya128/winevdm/issues/759 and https://github.com/otya128/winevdm/issues/638
Also fixes https://github.com/otya128/winevdm/issues/828 but only with DIBPalette disabled (it doesn't like window redraw which is required for palette animation) so color fades don't work.