### PR TITLE
make timeout for sendmessage hwnd_broadcast much shorter and set smto…

### DIFF
--- a/ole2/ifs_thunk.c
+++ b/ole2/ifs_thunk.c
@@ -2146,3 +2146,43 @@ DWORD STDMETHODCALLTYPE IMessageFilter_32_16_HandleInComingCall(IMessageFilter *
     return result32__;
 }
 #endif
+#ifdef IFS1632_OVERWRITE_IDataObject_DAdvise
+HRESULT CDECL IDataObject_16_32_DAdvise(SEGPTR This, SEGPTR args16_pformatetc, DWORD args16_advf, SEGPTR args16_pAdvSink, SEGPTR args16_pdwConnection)
+{
+    IDataObject *iface32 = (IDataObject*)get_interface32(This);
+    HRESULT result__ = {0};
+    TYP16_HRESULT result16__ = {0};
+    FORMATETC * args32_pformatetc;
+    DWORD args32_advf;
+    IAdviseSink * args32_pAdvSink;
+    DWORD args32_pdwConnection = {0};
+    MAP_PTR_FORMATETC16_32(args32_pformatetc, args16_pformatetc);
+    MAP_DWORD16_32(args32_advf, args16_advf);
+    args32_pAdvSink = iface16_32(&IID_IAdviseSink, args16_pAdvSink);
+    if (args32_pformatetc->ptd)
+    {
+        IPersist *pPersist;
+        iface32->lpVtbl->QueryInterface(iface32, &IID_IPersist, &pPersist);
+        if (pPersist)
+        {
+            CLSID clsid;
+            if (SUCCEEDED(pPersist->lpVtbl->GetClassID(pPersist, &clsid)) && CoIsOle1Class(&clsid))
+            {
+                HeapFree(GetProcessHeap(), 0, args32_pformatetc->ptd);
+                args32_pformatetc->ptd = NULL;
+            }
+            pPersist->lpVtbl->Release(pPersist);
+        }
+    }
+    TRACE("(%04x:%04x(%p),%08x,%08x,%08x,%08x)\n", SELECTOROF(This), OFFSETOF(This), iface32, args16_pformatetc, args16_advf, args16_pAdvSink, args16_pdwConnection);
+    result__ = (HRESULT)iface32->lpVtbl->DAdvise(iface32, args32_pformatetc, args32_advf, args32_pAdvSink, &args32_pdwConnection);
+    MAP_HRESULT32_16(result16__, result__);
+    UNMAP_PTR_FORMATETC16_32(args32_pformatetc, args16_pformatetc);
+    UNMAP_DWORD16_32(args32_advf, args16_advf);
+    if (args16_pdwConnection)
+    {
+        MAP_DWORD32_16((*(TYP16_DWORD*)MapSL(args16_pdwConnection)), args32_pdwConnection);
+    }
+    return result16__;
+}
+#endif

--- a/ole2/ifs_thunk.h
+++ b/ole2/ifs_thunk.h
@@ -1062,4 +1062,7 @@ HRESULT CDECL ITypeLib_16_32_FindName(SEGPTR This, SEGPTR args16_szNameBuf, DWOR
 #define IFS3216_OVERWRITE_IMessageFilter_HandleInComingCall
 DWORD STDMETHODCALLTYPE IMessageFilter_32_16_HandleInComingCall(IMessageFilter *This, DWORD dwCallType,HTASK htaskCaller,DWORD dwTickCount,LPINTERFACEINFO lpInterfaceInfo);
 
+#define IFS1632_OVERWRITE_IDataObject_DAdvise
+HRESULT CDECL IDataObject_16_32_DAdvise(SEGPTR This, SEGPTR args16_pformatetc, DWORD args16_advf, SEGPTR args16_pAdvSink, SEGPTR args16_pdwConnection);
+
 #endif

--- a/user/message.c
+++ b/user/message.c
@@ -2960,8 +2960,12 @@ static LRESULT send_message_timeout_callback( HWND hwnd, UINT msg, WPARAM wp, LP
                                       LRESULT *result, void *arg )
 {
     DWORD count;
+    LRESULT success;
     ReleaseThunkLock(&count);
-    LRESULT success = SendMessageTimeoutA(hwnd, msg, wp, lp, SMTO_NORMAL, 1000, result);
+    if (hwnd == HWND_BROADCAST)
+        success = SendMessageTimeoutA(hwnd, msg, wp, lp, SMTO_ABORTIFHUNG, 100, result);
+    else
+        success = SendMessageTimeoutA(hwnd, msg, wp, lp, SMTO_NORMAL, 1000, result);
     RestoreThunkLock(count);
     if (!success)
     {

--- a/user/message.c
+++ b/user/message.c
@@ -2963,7 +2963,19 @@ static LRESULT send_message_timeout_callback( HWND hwnd, UINT msg, WPARAM wp, LP
     LRESULT success;
     ReleaseThunkLock(&count);
     if (hwnd == HWND_BROADCAST)
-        success = SendMessageTimeoutA(hwnd, msg, wp, lp, SMTO_ABORTIFHUNG, 100, result);
+    {
+        int timeout = 1000;
+        switch (msg)
+        {
+            case WM_PALETTECHANGED:
+            case WM_SYSCOLORCHANGE:
+            case WM_FONTCHANGE:
+            case WM_SETTINGCHANGE:
+                timeout = 100;
+                break;
+        }
+        success = SendMessageTimeoutA(hwnd, msg, wp, lp, SMTO_ABORTIFHUNG, timeout, result);
+    }
     else
         success = SendMessageTimeoutA(hwnd, msg, wp, lp, SMTO_NORMAL, 1000, result);
     RestoreThunkLock(count);

--- a/user/user.c
+++ b/user/user.c
@@ -2202,6 +2202,8 @@ UINT16 WINAPI GlobalGetAtomName16(ATOM nAtom, LPSTR lpBuffer, INT16 nSize)
     /* win32 wow32:if specify a small buffer, GlobalGetAtomName returns 0 */
     /* win16      :if specify a small buffer, GlobalGetAtomName returns max(0, nSize - 1) */
     UINT len = GlobalGetAtomNameA(nAtom, buffer, 256);
+    if (!len)
+        return 0;
     if (len + 1 <= nSize)
     {
         memcpy(lpBuffer, buffer, len + 1);


### PR DESCRIPTION
…_abortifhung

Fixes a deadlock when using a msworks 2 spreadsheet with OLE.

Last commit fixes msdraw ole1 object.  msdraw doesn't use olesvr, it has it's own ole1 server implementation.

Last commit fixes winword crashing with msdraw objects.  winword 6 win32 appears to do this.