### PR TITLE
reduce flickering in 8bpp mode by fixing excessive redraw when palett…

### DIFF
--- a/gdi/gdi.c
+++ b/gdi/gdi.c
@@ -1679,16 +1679,18 @@ HBITMAP16 WINAPI CreateBitmap16( INT16 width, INT16 height, UINT16 planes,
 {
     if (krnl386_get_compat_mode("256color") && (bpp == 8) && (planes == 1))
     {
-        HDC dc = GetDC(NULL);
         HBITMAP16 ret;
         if (krnl386_get_config_int("otvdm", "DIBPalette", FALSE))
         {
-            ret = CreateCompatibleBitmap16(HDC_16(dc), width, height);
+            HDC16 dc = CreateCompatibleDC16(NULL);
+            ret = CreateCompatibleBitmap16(dc, width, height);
             if (bits)
                 SetBitmapBits(HBITMAP_32(ret), width * height, bits);
+            DeleteDC16(dc);
         }
         else
         {
+            HDC dc = GetDC(NULL);
             HBITMAP ret32 = CreateCompatibleBitmap(dc, width, height);
             if (bits)
             {
@@ -1706,8 +1708,8 @@ HBITMAP16 WINAPI CreateBitmap16( INT16 width, INT16 height, UINT16 planes,
                 HeapFree(GetProcessHeap(), 0, bmap);
             }
             ret = HBITMAP_16(ret32);
+            ReleaseDC(NULL, dc);
         }
-        ReleaseDC(NULL, dc);
         return ret;
     }
     else if ((planes == 1) && (bpp > 8))

--- a/otvdm.ini
+++ b/otvdm.ini
@@ -106,9 +106,6 @@
 ; Emulate 8bpp color mode using DIBs (default: 0)
 ;DIBPalette=0
 
-; Redraw the window when a palette is realized in 8bpp mode (default: 0)
-;RealizeRedraw=0
-
 ; If EnumFontLimitation=1, this section declare the font to be enumerated.
 ;[EnumFontLimitation]
 ;font name=1(enumerated)/0(not enumerated)

--- a/user/user.c
+++ b/user/user.c
@@ -2318,9 +2318,6 @@ UINT16 WINAPI RealizePalette16( HDC16 hdc )
         if (krnl386_get_config_int("otvdm", "DIBPalette", FALSE)
             && (GetDeviceCaps(hdc32, TECHNOLOGY) == DT_RASDISPLAY) && (GetObjectType(hdc32) == OBJ_DC))
             set_realized_palette(hdc32);
-        HWND hwnd = WindowFromDC(hdc32);
-        if (hwnd && krnl386_get_config_int("otvdm", "RealizeRedraw", FALSE))
-            RedrawWindow(hwnd, NULL, NULL, RDW_INTERNALPAINT);
     }
         
     return UserRealizePalette(hdc32);


### PR DESCRIPTION
…e changes

remove realizeredraw which isn't needed with other changes add helper for handling dib colors to behave more like real 8bpp mode only the back color affects 1bpp dst conversion
make 1bpp setdibits fix more compatible