### PR TITLE
only replace the wndproc when a library is freed it is a win16 proc

### DIFF
--- a/krnl386/local.c
+++ b/krnl386/local.c
@@ -1017,7 +1017,7 @@ notify_done:
 	    if (call_notify_func(pInfo->notify, LN_OUTOFMEM, ds - 20, size)) /* FIXME: "size" correct ? (should indicate bytes needed) */
 		goto notify_done;
 #endif
-            ERR( "not enough space in %s heap %04x for %d bytes\n",
+            WARN( "not enough space in %s heap %04x for %d bytes\n",
                  get_heap_name(ds), ds, size );
 	    return 0;
 	}
@@ -1026,7 +1026,7 @@ notify_done:
 	arena = LOCAL_FindFreeBlock( ds, size, flags );
     }
     if (arena == 0) {
-        ERR( "not enough space in %s heap %04x for %d bytes\n",
+        WARN( "not enough space in %s heap %04x for %d bytes\n",
              get_heap_name(ds), ds, size );
 #if 0
         /* FIXME: "size" correct ? (should indicate bytes needed) */

--- a/user/window.c
+++ b/user/window.c
@@ -63,6 +63,7 @@ void WINAPI K32WOWHandle16DestroyHint(HANDLE handle, WOW_HANDLE_TYPE type);
 BOOL16 WINAPI IsOldWindowsTask(HINSTANCE16 hInst);
 BYTE get_aflags(HMODULE16 hModule);
 ULONG WINAPI get_windows_build();
+LRESULT CALLBACK WindowProc16(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam);
 /* size of buffer needed to store an atom string */
 #define ATOM_BUFFER_SIZE 256
 
@@ -132,7 +133,8 @@ BOOL CALLBACK remove_wndproc(HWND hwnd, LPARAM lparam)
     {
         TRACE("HWND %x WNDPROC removed\n", hwnd);
         EnumChildWindows(hwnd, remove_wndproc, lparam);
-        SetWindowLongPtrA(hwnd, GWLP_WNDPROC, DefWindowProcA);
+        if (GetWindowLongPtrA(hwnd, GWL_WNDPROC) == (LONG_PTR)WindowProc16)
+            SetWindowLongPtrA(hwnd, GWLP_WNDPROC, DefWindowProcA);
     }
     return TRUE;
 }
@@ -1705,7 +1707,6 @@ LRESULT get_message_callback(HWND16 hwnd, UINT16 msg, WPARAM16 wp, LPARAM lp,
 LRESULT call_window_proc16(HWND16 hwnd, UINT16 msg, WPARAM16 wParam, LPARAM lParam,
     LRESULT *result, void *arg);
 LRESULT CALLBACK DlgProcCall16(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam);
-LRESULT CALLBACK WindowProc16(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK DlgProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam);
 WNDPROC get_classinfo_wndproc(const char *class);
 /**********************************************************************


### PR DESCRIPTION
fixes https://github.com/otya128/winevdm/issues/1514

Concept loads a library that creates a dialog with only the default window procs then frees the library.  remove_wndproc then would replace DefDialogProc with DefWindowProc breaking the dialog.  This should only remove win16 procs and leave user32 ones alone.