### PR TITLE
prevent olesvr32 from being unloaded as it will fail to load again du…

### DIFF
--- a/olesvr/olesvr.c
+++ b/olesvr/olesvr.c
@@ -766,3 +766,10 @@ INT16 CALLBACK ItemCallBack16(LPOLECLIENT client, OLE_NOTIFICATION16 notif, SEGP
     // oleobject must have been created with GetObject
     return ItemCallBack(client, notif, &find_oleobject(oleobject)->obj);
 }
+
+BOOL WINAPI DllEntryPoint16(DWORD reason, HINSTANCE16 inst, WORD ds, WORD heap, DWORD reserved1, WORD reserved2)
+{
+    // olesvr32 has a bug where it will fail to load again if it is unloaded so force it to stay loaded
+    LoadLibraryA("olesvr32.dll");
+    return TRUE;
+}

--- a/olesvr/olesvr.dll16.spec
+++ b/olesvr/olesvr.dll16.spec
@@ -21,3 +21,4 @@
 29 stub DELETECLIENTINFO
 30 stub SENDRENAMEMSG
 31 stub ENUMFORTERMINATE
+32 pascal -ret16 DllEntryPoint(long word word word long word) DllEntryPoint16


### PR DESCRIPTION
…e to it failing to unregister it's window classes so when it loads registerclass won't work