### PR TITLE
don't run contents() macro from help config section

### DIFF
--- a/winhlp32/winhelp.c
+++ b/winhlp32/winhelp.c
@@ -1187,7 +1187,12 @@ BOOL WINHELP_CreateHelpWindow(WINHELP_WNDPAGE* wpage, int nCmdShow, BOOL remembe
     {
         HLPFILE_MACRO  *macro;
         for (macro = wpage->page->file->first_macro; macro; macro = macro->next)
+        {
+            // don't jump to contents on every page load
+            if (!strcmp(macro->lpszMacro, "Contents()"))
+                continue;
             MACRO_ExecuteMacro(win, macro->lpszMacro);
+        }
 
         for (macro = wpage->page->first_macro; macro; macro = macro->next)
             MACRO_ExecuteMacro(win, macro->lpszMacro);


### PR DESCRIPTION
The wizardry gold help file has a pointless contents() macro in the global macro section but since those macros are run on every page load rather than only on file load it always redirects back to content on every link click.  The macros should only be run once on help file load but button handling will be a lot harder then so since this is the only help file I found that has this problem hopefully it's very rare.