### PR TITLE
install: mirror handler keys under WOW6432Node

### DIFF
--- a/install.inf
+++ b/install.inf
@@ -8,6 +8,8 @@ AddReg=DefaultInstall.ntamd64.AddReg
 [DefaultInstall.ntamd64.DelReg]
 HKLM,%NtVdm64%\OTVDM
 HKLM,%NtVdm64%\OTVDM,,0x4000
+HKLM,%NtVdm64Wow%\OTVDM
+HKLM,%NtVdm64Wow%\OTVDM,,0x4000
 
 [DefaultInstall.ntamd64.AddReg]
 HKLM,%NtVdm64%\0OTVDM,CommandLine,,%CommandLine%
@@ -20,9 +22,20 @@ HKLM,%NtVdm64%\0OTVDM,InternalName,0x4000,*
 HKLM,%NtVdm64%\0OTVDM,ProductName,0x4000,*
 HKLM,%NtVdm64%\0OTVDM,ProductVersion,0x4000,*
 HKLM,%NtVdm64%\0OTVDM,MappedExeName,0x4000,%01%\%MappedExeName%
+HKLM,%NtVdm64Wow%\0OTVDM,CommandLine,,%CommandLine%
+HKLM,%NtVdm64Wow%\0OTVDM,InternalName,,*
+HKLM,%NtVdm64Wow%\0OTVDM,ProductName,,*
+HKLM,%NtVdm64Wow%\0OTVDM,ProductVersion,,*
+HKLM,%NtVdm64Wow%\0OTVDM,MappedExeName,,%01%\%MappedExeName%
+HKLM,%NtVdm64Wow%\0OTVDM,CommandLine,0x4000,%CommandLine%
+HKLM,%NtVdm64Wow%\0OTVDM,InternalName,0x4000,*
+HKLM,%NtVdm64Wow%\0OTVDM,ProductName,0x4000,*
+HKLM,%NtVdm64Wow%\0OTVDM,ProductVersion,0x4000,*
+HKLM,%NtVdm64Wow%\0OTVDM,MappedExeName,0x4000,%01%\%MappedExeName%
 
 [Strings]
 NtVdm64=SOFTWARE\Microsoft\Windows NT\CurrentVersion\NtVdm64
+NtVdm64Wow=SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\NtVdm64
 CommandLine=" --ntvdm64: ""%m"" --ntvdm64-args: %c"
 ;If you want to hide the console window, change otvdm.exe to otvdmw.exe
 MappedExeName=otvdm.exe

--- a/installw.inf
+++ b/installw.inf
@@ -8,6 +8,8 @@ AddReg=DefaultInstall.ntamd64.AddReg
 [DefaultInstall.ntamd64.DelReg]
 HKLM,%NtVdm64%\OTVDM
 HKLM,%NtVdm64%\OTVDM,,0x4000
+HKLM,%NtVdm64Wow%\OTVDM
+HKLM,%NtVdm64Wow%\OTVDM,,0x4000
 
 [DefaultInstall.ntamd64.AddReg]
 HKLM,%NtVdm64%\0OTVDM,CommandLine,,%CommandLine%
@@ -20,9 +22,20 @@ HKLM,%NtVdm64%\0OTVDM,InternalName,0x4000,*
 HKLM,%NtVdm64%\0OTVDM,ProductName,0x4000,*
 HKLM,%NtVdm64%\0OTVDM,ProductVersion,0x4000,*
 HKLM,%NtVdm64%\0OTVDM,MappedExeName,0x4000,%01%\%MappedExeName%
+HKLM,%NtVdm64Wow%\0OTVDM,CommandLine,,%CommandLine%
+HKLM,%NtVdm64Wow%\0OTVDM,InternalName,,*
+HKLM,%NtVdm64Wow%\0OTVDM,ProductName,,*
+HKLM,%NtVdm64Wow%\0OTVDM,ProductVersion,,*
+HKLM,%NtVdm64Wow%\0OTVDM,MappedExeName,,%01%\%MappedExeName%
+HKLM,%NtVdm64Wow%\0OTVDM,CommandLine,0x4000,%CommandLine%
+HKLM,%NtVdm64Wow%\0OTVDM,InternalName,0x4000,*
+HKLM,%NtVdm64Wow%\0OTVDM,ProductName,0x4000,*
+HKLM,%NtVdm64Wow%\0OTVDM,ProductVersion,0x4000,*
+HKLM,%NtVdm64Wow%\0OTVDM,MappedExeName,0x4000,%01%\%MappedExeName%
 
 [Strings]
 NtVdm64=SOFTWARE\Microsoft\Windows NT\CurrentVersion\NtVdm64
+NtVdm64Wow=SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\NtVdm64
 CommandLine=" --ntvdm64: ""%m"" --ntvdm64-args: %c"
 ;If you want to hide the console window, change otvdm.exe to otvdmw.exe
 MappedExeName=otvdmw.exe


### PR DESCRIPTION
The `install.inf` / `installw.inf` AddReg sections only write the `0OTVDM` handler under `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\NtVdm64`. When a 32-bit process (e.g. a modern InstallShield bootstrapper) spawns a 16-bit child, the lookup goes through the WOW6432Node registry redirector and misses the key, so the OS still shows "Unsupported 16-Bit Application" despite a successful install.

Hit this with an IS5 installer whose 32-bit stub launches the bundled 16-bit `SETUP.EXE`. Mirroring the keys to `SOFTWARE\WOW6432Node\...` fixes it.

`uninstall.reg` already deletes both branches, so this also makes install and uninstall symmetric.