### PR TITLE
Synchronize OPENFILENAME16 before FileNameOK hooks

### DIFF
--- a/commdlg/cdlg16.h
+++ b/commdlg/cdlg16.h
@@ -170,7 +170,6 @@ typedef struct
     BOOL used;
     SEGPTR segofn16;
     SEGPTR func;
-    OPENFILENAMEA *ofn32;
     union
     {
         OPENFILENAME16 ofn16;

--- a/commdlg/cdlg16.h
+++ b/commdlg/cdlg16.h
@@ -170,6 +170,7 @@ typedef struct
     BOOL used;
     SEGPTR segofn16;
     SEGPTR func;
+    OPENFILENAMEA *ofn32;
     union
     {
         OPENFILENAME16 ofn16;

--- a/commdlg/filedlg.c
+++ b/commdlg/filedlg.c
@@ -50,10 +50,9 @@ UINT WMWOWDirChange;
 LPDLGTEMPLATEA resource_to_dialog32(HINSTANCE16 hInst, LPCSTR name, WORD *res);
 LPDLGTEMPLATEA handle_to_dialog32(HGLOBAL16 hg, WORD *res);
 
-static void sync_fileok_ofn16(COMMDLGTHUNK *thunk, HWND hwnd)
+static void sync_fileok_ofn16(COMMDLGTHUNK *thunk, HWND hwnd, OPENFILENAMEA *ofn32)
 {
     LPOPENFILENAME16 lpofn;
-    OPENFILENAMEA *ofn32;
     LPSTR file;
     UINT max_file;
     UINT len;
@@ -66,26 +65,34 @@ static void sync_fileok_ofn16(COMMDLGTHUNK *thunk, HWND hwnd)
     lpofn = MapSL(thunk->segofn16);
     if (!lpofn) return;
 
-    ofn32 = thunk->ofn32;
     file = ofn32 && ofn32->lpstrFile ? ofn32->lpstrFile : MapSL(lpofn->lpstrFile);
     max_file = ofn32 && ofn32->nMaxFile ? ofn32->nMaxFile : lpofn->nMaxFile;
     if (!file || !max_file) return;
 
-    GetDlgItemTextA(hwnd, edt1, file, max_file);
+    if (!file[0])
+        GetDlgItemTextA(hwnd, edt1, file, max_file);
     len = (UINT)min(strlen(file), max_file - 1);
 
-    for (i = 0; i < len; i++)
+    if (ofn32 && ofn32->nFileOffset)
     {
-        if (file[i] == '\\' || file[i] == '/' || file[i] == ':')
-            file_offset = i + 1;
+        file_offset = ofn32->nFileOffset;
+        file_extension = ofn32->nFileExtension;
     }
-
-    for (i = len; i > file_offset; i--)
+    else
     {
-        if (file[i - 1] == '.')
+        for (i = 0; i < len; i++)
         {
-            file_extension = i;
-            break;
+            if (file[i] == '\\' || file[i] == '/' || file[i] == ':')
+                file_offset = i + 1;
+        }
+
+        for (i = len; i > file_offset; i--)
+        {
+            if (file[i - 1] == '.')
+            {
+                file_extension = i;
+                break;
+            }
         }
     }
 
@@ -103,12 +110,13 @@ static void sync_fileok_ofn16(COMMDLGTHUNK *thunk, HWND hwnd)
 LRESULT WINAPI DIALOG_CallDialogProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, WNDPROC16 proc);
 static UINT_PTR CALLBACK thunk_hook(COMMDLGTHUNK *thunk, HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
 {
+    if (msg == WMFILEOK) sync_fileok_ofn16(thunk, hwnd, (OPENFILENAMEA *)lp);
+
     /* window message hook? */
     if (msg == WM_INITDIALOG || msg == WMFILEOK || msg == WMHELPMSG || msg == WMFINDMSG || msg == WMCOLOROK || msg == WMSHAREVI)
     {
         lp = thunk->segofn16;
     }
-    if (msg == WMFILEOK) sync_fileok_ofn16(thunk, hwnd);
     UINT_PTR result = DIALOG_CallDialogProc(hwnd, msg, wp, lp, (WNDPROC16)thunk->func);
     return result;
 }
@@ -153,7 +161,6 @@ COMMDLGTHUNK *allocate_thunk(SEGPTR ofnseg, SEGPTR func)
             thunk_array[i].used     = TRUE;
             thunk_array[i].func     = func;
             thunk_array[i].segofn16 = ofnseg;
-            thunk_array[i].ofn32    = NULL;
             return thunk_array + i;
         }
     }
@@ -347,7 +354,6 @@ BOOL16 WINAPI GetOpenFileName16( SEGPTR ofn ) /* [in/out] address of structure w
         if (thunk)
         {
             thunk->ofn16 = ofn16;
-            thunk->ofn32 = &ofn32;
             ofn32.lpfnHook = (LPOFNHOOKPROC)thunk;
         }
         else
@@ -443,7 +449,6 @@ BOOL16 WINAPI GetSaveFileName16( SEGPTR ofn ) /* [in/out] address of structure w
         if (thunk)
         {
             thunk->ofn16 = ofn16;
-            thunk->ofn32 = &ofn32;
             ofn32.lpfnHook = (LPOFNHOOKPROC)thunk;
         }
         else

--- a/commdlg/filedlg.c
+++ b/commdlg/filedlg.c
@@ -36,6 +36,9 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(commdlg);
 #define MAX_THUNK 5
+#ifndef edt1
+#define edt1 0x0480
+#endif
 COMMDLGTHUNK *thunk_array;
 UINT WMFILEOK;
 UINT WMHELPMSG;
@@ -47,6 +50,56 @@ UINT WMWOWDirChange;
 LPDLGTEMPLATEA resource_to_dialog32(HINSTANCE16 hInst, LPCSTR name, WORD *res);
 LPDLGTEMPLATEA handle_to_dialog32(HGLOBAL16 hg, WORD *res);
 
+static void sync_fileok_ofn16(COMMDLGTHUNK *thunk, HWND hwnd)
+{
+    LPOPENFILENAME16 lpofn;
+    OPENFILENAMEA *ofn32;
+    LPSTR file;
+    UINT max_file;
+    UINT len;
+    UINT file_offset = 0;
+    UINT file_extension = 0;
+    UINT i;
+
+    if (!thunk) return;
+
+    lpofn = MapSL(thunk->segofn16);
+    if (!lpofn) return;
+
+    ofn32 = thunk->ofn32;
+    file = ofn32 && ofn32->lpstrFile ? ofn32->lpstrFile : MapSL(lpofn->lpstrFile);
+    max_file = ofn32 && ofn32->nMaxFile ? ofn32->nMaxFile : lpofn->nMaxFile;
+    if (!file || !max_file) return;
+
+    GetDlgItemTextA(hwnd, edt1, file, max_file);
+    len = (UINT)min(strlen(file), max_file - 1);
+
+    for (i = 0; i < len; i++)
+    {
+        if (file[i] == '\\' || file[i] == '/' || file[i] == ':')
+            file_offset = i + 1;
+    }
+
+    for (i = len; i > file_offset; i--)
+    {
+        if (file[i - 1] == '.')
+        {
+            file_extension = i;
+            break;
+        }
+    }
+
+    lpofn->nFileOffset = file_offset;
+    lpofn->nFileExtension = file_extension;
+    if (ofn32)
+    {
+        ofn32->nFileOffset = file_offset;
+        ofn32->nFileExtension = file_extension;
+        if (ofn32->nFilterIndex)
+            lpofn->nFilterIndex = ofn32->nFilterIndex;
+    }
+}
+
 LRESULT WINAPI DIALOG_CallDialogProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, WNDPROC16 proc);
 static UINT_PTR CALLBACK thunk_hook(COMMDLGTHUNK *thunk, HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
 {
@@ -55,6 +108,7 @@ static UINT_PTR CALLBACK thunk_hook(COMMDLGTHUNK *thunk, HWND hwnd, UINT msg, WP
     {
         lp = thunk->segofn16;
     }
+    if (msg == WMFILEOK) sync_fileok_ofn16(thunk, hwnd);
     UINT_PTR result = DIALOG_CallDialogProc(hwnd, msg, wp, lp, (WNDPROC16)thunk->func);
     return result;
 }
@@ -99,6 +153,7 @@ COMMDLGTHUNK *allocate_thunk(SEGPTR ofnseg, SEGPTR func)
             thunk_array[i].used     = TRUE;
             thunk_array[i].func     = func;
             thunk_array[i].segofn16 = ofnseg;
+            thunk_array[i].ofn32    = NULL;
             return thunk_array + i;
         }
     }
@@ -288,9 +343,14 @@ BOOL16 WINAPI GetOpenFileName16( SEGPTR ofn ) /* [in/out] address of structure w
 
     if (lpofn->Flags & OFN_ENABLEHOOK)
     {
-        ofn32.lpfnHook = (LPOFNHOOKPROC)allocate_thunk(ofn, (SEGPTR)lpofn->lpfnHook);
-        ((COMMDLGTHUNK*)ofn32.lpfnHook)->ofn16 = ofn16;
-        if (!ofn32.lpfnHook)
+        COMMDLGTHUNK *thunk = allocate_thunk(ofn, (SEGPTR)lpofn->lpfnHook);
+        if (thunk)
+        {
+            thunk->ofn16 = ofn16;
+            thunk->ofn32 = &ofn32;
+            ofn32.lpfnHook = (LPOFNHOOKPROC)thunk;
+        }
+        else
         {
             ERR("could not allocate GetOpenFileName16 thunk\n");
             ofn32.lpfnHook = dummy_hook;
@@ -379,9 +439,14 @@ BOOL16 WINAPI GetSaveFileName16( SEGPTR ofn ) /* [in/out] address of structure w
 
     if (lpofn->Flags & OFN_ENABLEHOOK)
     {
-        ofn32.lpfnHook = (LPOFNHOOKPROC)allocate_thunk(ofn, (SEGPTR)lpofn->lpfnHook);
-        ((COMMDLGTHUNK*)ofn32.lpfnHook)->ofn16 = ofn16;
-        if (!ofn32.lpfnHook)
+        COMMDLGTHUNK *thunk = allocate_thunk(ofn, (SEGPTR)lpofn->lpfnHook);
+        if (thunk)
+        {
+            thunk->ofn16 = ofn16;
+            thunk->ofn32 = &ofn32;
+            ofn32.lpfnHook = (LPOFNHOOKPROC)thunk;
+        }
+        else
         {
             ERR("could not allocate GetOpenFileName16 thunk\n");
             ofn32.lpfnHook = dummy_hook;


### PR DESCRIPTION
## Summary
- keep the active OPENFILENAMEA on the Win16 common-dialog thunk
- before forwarding the registered FileNameOK message to a Win16 hook, copy the current old-style file-dialog edit control text into OPENFILENAME16
- recompute nFileOffset and nFileExtension so hook-based validation sees the selected filename

## Details
GetOpenFileName16 and GetSaveFileName16 already copy nFilterIndex, nFileOffset, and nFileExtension back after the native dialog returns. Some Win16 applications validate lpstrFile/nFileExtension inside their OFN_ENABLEHOOK FileNameOK callback, before that post-return copyback happens. In that path the hook can see stale or empty OPENFILENAME16 fields even though the dialog edit control contains the selected filename.

This change synchronizes the file dialog state immediately before calling the Win16 hook for WMFILEOK/FileNameOK. The existing post-return copyback is preserved.

## Validation
- Built convspec in a clean clone with VS2022/MSBuild.
- Built commdlg until link dependency resolution; filedlg.c compiled successfully. The link then stopped because the fresh partial clone build had not produced WineVDM dependency libraries such as user.lib.
- Locally built commdlg.dll16 in an existing WineVDM build tree and tested against a Win16 application that validates file extensions in its FileNameOK hook. Before the fix the hook saw an empty lpstrFile; after the fix it saw SOFTWARE.BTN with nFileExtension pointing to BTN.