### PR TITLE
krnl386: don't write dwExpWinVer into the TEB on Wine (it aliases win32u's client_imm)

### DIFF
--- a/krnl386/task.c
+++ b/krnl386/task.c
@@ -621,7 +621,13 @@ static void set_thread_internal_windows_ver(DWORD version)
         /* init user32 */
         PeekMessageW(&msg, NULL, 0, 0, 0);
     }
-    *lpdwExpWinVer = version;
+    /* On Wine's new WoW64 this TEB slot is win32u's client_imm, not dwExpWinVer;
+     * writing 0x030A here crashes imm32.  Wine gets the version from the module, so skip. */
+    {
+        HMODULE ntdll = GetModuleHandleA("ntdll.dll");
+        if (!(ntdll && GetProcAddress(ntdll, "wine_get_version")))
+            *lpdwExpWinVer = version;
+    }
 }
 
 static void cwd_warning(void)


### PR DESCRIPTION
### Problem

On the **new WoW64** path, a 16-bit app that creates a top-level window or dialog crashes inside `imm32` while the emulator brings up the guest UI. It's not app-specific — any Win3.x task hits it.

### Root cause

`set_thread_internal_windows_ver()` writes `dwExpWinVer` into the TEB `Win32ClientInfo` block using the **real-Windows** CLIENTINFO layout (`wow64teb + 0x800 + 0x10`). That is correct on genuine Windows/WoW64. But under **Wine's new WoW64**, `Win32ClientInfo` is *not* the Windows CLIENTINFO — win32u owns that block as its private `struct ntuser_thread_info`, and its `client_imm` field sits at exactly the same byte (`Win32ClientInfo + 0x10`). So the write stamps the version constant (`0x030A` for a Win3.1 app) straight onto `client_imm`.

The next window/dialog creation runs imm32's implicit COM init, which does `get_thread_coinit_spy()` → returns `client_imm` as a `coinit_spy*` and dereferences it — now `0x030A` — access violation, wedging the emulator.

On Wine the write is also **dead**: winevdm derives the expected version from the module (`GetExpWinVer16` / `ne_expver`), never from this TEB slot. So it does nothing useful on Wine while actively corrupting win32u state.

### Scope — not host-specific

The overlap is in OS-agnostic win32u code and the write is unconditional per 16-bit task, so this reproduces on **any** Wine host running new WoW64 — including **Linux** since Wine **10.16** added 16-bit apps under new WoW64. (First hit on Apple Silicon via Gcenx wine-staging 11.15 under Rosetta, but the cause is not the host.)

### Fix

Skip **only** the `dwExpWinVer` write when running on Wine (detected via `wine_get_version`). The `PeekMessageW` user32-init above it is kept, and real Windows is unchanged.

### Testing

Win3.x 16-bit app via winevdm on Gcenx wine-staging 11.15 (new WoW64, Apple Silicon/Rosetta): before — crash in `imm32!imm_coinit_thread` dereferencing `0x030A` on the first dialog; after — starts and runs, no imm32 crash, with stock upstream imm32.

---

_Supersedes #1607 — that approach (`ImmDisableIME`) masked the crash and disabled IME globally; this fixes the root TEB clobber instead._
