### PR TITLE
only delete menu if it's not attached to the window

### DIFF
--- a/user/window.c
+++ b/user/window.c
@@ -898,7 +898,9 @@ BOOL16 WINAPI DestroyWindow16( HWND16 hwnd )
 {
     DWORD count;
     BOOL result;
-    HMENU16 hmenu16 = GetMenu16(hwnd);
+    HMENU16 hmenu16 = NULL;
+    HWND hwnd32 = HWND_32(hwnd);
+    if(!GetMenu(hwnd32)) hmenu16 = GetMenu16(hwnd);
     ReleaseThunkLock(&count);
     result = DestroyWindow(WIN_Handle32(hwnd));
     RestoreThunkLock(count);


### PR DESCRIPTION
Zombie wars removes the menu from the window in WM_DESTROY so it shouldn't be deleted.  Since in https://github.com/otya128/winevdm/commit/a873237cf74da2860b8a202fb917d63b323255d2 the menu is bound to the hwnd16 but not to the real window check getmenu to see if windows will delete the menu itself.